### PR TITLE
[codex] add upstream sync automation

### DIFF
--- a/.fork/patches/0001-release-and-branding.patch
+++ b/.fork/patches/0001-release-and-branding.patch
@@ -1,0 +1,2383 @@
+diff --git a/.dockerignore b/.dockerignore
+new file mode 100644
+index 0000000000000000000000000000000000000000..a61dd7b86a6a7a3f37c5eeeefae65c2f2577e4a9
+--- /dev/null
++++ b/.dockerignore
+@@ -0,0 +1,43 @@
++# Local testing
++local-test/
++scripts/
++
++# Build artifacts (keep Sonarr/ — needed by local Dockerfile)
++_output*/
++_artifacts/
++_tests*/
++_publish*/
++_temp*/
++_rawPackage/
++docker-context/
++TestResults/
++
++# Git and IDE
++.git/
++.github/
++.vs/
++.idea/
++.claude/
++
++# Logs and databases
++*.log
++*.trace*.txt
++*.debug*.txt
++*.db
++*.db-shm
++*.db-wal
++
++# Source (not needed in runtime image)
++src/
++frontend/
++node_modules/
++
++# Packages
++Sonarr_*/
++*.zip
++*.gz
++
++# Docs
++*.md
++docs/
++LICENSE
+diff --git a/.github/ISSUE_TEMPLATE/bug_report.yml b/.github/ISSUE_TEMPLATE/bug_report.yml
+index 4e4eedb66440356afbfb4e387e01f7c1a2f1f3d7..c54296cb4faef5963c1b4f6393c90a9f815e93c9 100644
+--- a/.github/ISSUE_TEMPLATE/bug_report.yml
++++ b/.github/ISSUE_TEMPLATE/bug_report.yml
+@@ -1,81 +1,103 @@
+ name: Bug Report
+-description: 'Only bug reports for v4 will be accepted, older versions are no longer receiving bug fixes and support issues will be closed immediately.'
+-labels: ['needs-triage']
++description: Report an anime search bug in sonarr-anime
++labels: ['bug']
+ body:
+ - type: checkboxes
+   attributes:
+-    label: Is there an existing issue for this?
+-    description: Please search to see if an open or closed issue already exists for the bug you encountered. If a bug exists and it is closed as complete it may not yet be in a stable release.
++    label: Pre-flight checks
+     options:
+-    - label: I have searched the existing open and closed issues
++    - label: I have searched existing open and closed issues
+       required: true
+-- type: textarea
++    - label: This bug is specific to sonarr-anime (not upstream Sonarr behavior)
++      required: true
++- type: input
+   attributes:
+-    label: Current Behavior
+-    description: A concise description of what you're experiencing.
++    label: Fork version
++    description: "sonarr-anime version (e.g. 4.0.17.812) — check System > Status in the UI"
++    placeholder: "4.0.17.812"
+   validations:
+     required: true
+-- type: textarea
++- type: dropdown
++  attributes:
++    label: Install type
++    options:
++      - GHCR Docker image
++      - Release archive
++      - Local build
++  validations:
++    required: true
++- type: dropdown
++  attributes:
++    label: Indexer path
++    description: How does Sonarr reach the indexer?
++    options:
++      - Native Nyaa (built-in indexer)
++      - Prowlarr / Torznab
++      - Prowlarr / Newznab
++      - Other
++  validations:
++    required: true
++- type: dropdown
+   attributes:
+-    label: Expected Behavior
+-    description: A concise description of what you expected to happen.
++    label: Public or private indexer?
++    options:
++      - Public (e.g. Nyaa, AnimeTosho)
++      - Private
++  validations:
++    required: true
++- type: input
++  attributes:
++    label: Series and seasons searched
++    description: "e.g. Sword Art Online S01-S04"
++    placeholder: "Series Name S01"
+   validations:
+     required: true
+ - type: textarea
+   attributes:
+-    label: Steps To Reproduce
+-    description: Steps to reproduce the behavior.
+-    placeholder: |
+-      1. In this environment...
+-      2. With this config...
+-      3. Run '...'
+-      4. See error...
++    label: Expected cascade behavior
++    description: What did you expect the search cascade to do? (e.g. pack search should have covered all episodes)
+   validations:
+-    required: false
++    required: true
+ - type: textarea
+   attributes:
+-    label: Environment
+-    description: |
+-      examples:
+-        - **OS**: Ubuntu 22.04
+-        - **Sonarr**: Sonarr 4.0.0.766
+-        - **Docker Install**: Yes
+-        - **Using Reverse Proxy**: No
+-        - **Browser**: Firefox 90 (If UI related)
+-        - **Database**: Sqlite 3.41.2
+-    value: |
+-        - OS: 
+-        - Sonarr: 
+-        - Docker Install: 
+-        - Using Reverse Proxy: 
+-        - Browser: 
+-        - Database: 
+-    render: markdown
++    label: Actual behavior
++    description: What actually happened?
+   validations:
+     required: true
+ - type: dropdown
+   attributes:
+-    label: What branch are you running?
++    label: Did per-episode fallback occur?
++    description: Check trace logs for individual episode queries after the pack/season search
+     options:
+-      - Main
+-      - Develop
+-      - Other (This issue will be closed)
++      - "Yes"
++      - "No"
++      - "Not sure"
+   validations:
+     required: true
+ - type: textarea
+   attributes:
+-    label: Trace Logs?
++    label: Trace logs
+     description: |
+-      Trace Logs (https://wiki.servarr.com/sonarr/troubleshooting#logging-and-log-files) 
+-      ***Generally speaking, all bug reports must have trace logs provided.***
+-      *** Info Logs are not trace logs. If the logs do not say trace and are not from a file like `*.trace.*.txt` they are not trace logs.***
++      Attach trace logs (Settings > General > Log Level: Trace). Look for files like `sonarr.trace.*.txt` in your config/logs directory.
++      **Info logs are not trace logs.** Without trace logs, most search bugs cannot be diagnosed.
++    placeholder: "Paste trace log excerpts or attach the file"
+   validations:
+     required: true
+ - type: textarea
+   attributes:
+-    label: Anything else?
++    label: E2E test output (if reproducible)
+     description: |
+-      Links? Screenshots? References? Anything that will give us more context about the issue you are encountering!
+-      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
++      If you can reproduce locally, run `/test-e2e` or `/test-e2e-prowlarr` and paste the report summary.
++  validations:
++    required: false
++- type: textarea
++  attributes:
++    label: Environment
++    description: OS, Docker version, reverse proxy, etc.
++    value: |
++        - OS:
++        - Docker:
++        - Reverse proxy:
++    render: markdown
+   validations:
+     required: false
+diff --git a/.github/ISSUE_TEMPLATE/config.yml b/.github/ISSUE_TEMPLATE/config.yml
+index 2fb2fa0a193f1401831c6fa29dbf9020eaaac265..11db9b0ccb893ae4f9f808206b1e67f0bf7599ae 100644
+--- a/.github/ISSUE_TEMPLATE/config.yml
++++ b/.github/ISSUE_TEMPLATE/config.yml
+@@ -1,14 +1,8 @@
+ blank_issues_enabled: false
+ contact_links:
+-  - name: Support via Discord
+-    url: https://discord.gg/M6BvZn5
+-    about: Chat with users and devs on support and setup related topics.
+-  - name: Support via Reddit
+-    url: https://reddit.com/r/Sonarr
+-    about: Discuss and search through support topics.
+-  - name: Support via Forums
+-    url: https://forums.sonarr.tv/
+-    about: Discuss and search through support topics.
+-  - name: Support via IRC
+-    url: https://web.libera.chat/?channels=#sonarr
+-    about: Chat with users and devs on support and setup related topics.
+\ No newline at end of file
++  - name: General Sonarr support
++    url: https://wiki.servarr.com/sonarr
++    about: For help with Sonarr features unrelated to this fork's anime search changes, use the upstream Sonarr wiki, forums, or Discord.
++  - name: Upstream Sonarr issues
++    url: https://github.com/Sonarr/Sonarr/issues
++    about: For bugs in Sonarr behavior that are not specific to this fork's anime search patches.
+diff --git a/.github/ISSUE_TEMPLATE/feature_request.yml b/.github/ISSUE_TEMPLATE/feature_request.yml
+index cd224373c95726784e218a03d94130f34b76c7a3..bcb4030d93b159a6c82bce0cf20df243838088bd 100644
+--- a/.github/ISSUE_TEMPLATE/feature_request.yml
++++ b/.github/ISSUE_TEMPLATE/feature_request.yml
+@@ -1,37 +1,35 @@
+ name: Feature Request
+-description: 'Suggest an idea for Sonarr'
+-labels: ['needs-triage']
++description: Suggest an improvement to the anime search pipeline
++labels: ['enhancement']
+ body:
++- type: markdown
++  attributes:
++    value: |
++      This fork has a narrow scope: reducing redundant anime search queries on Sonarr v4.
++      Feature requests outside this scope are better directed to [upstream Sonarr](https://github.com/Sonarr/Sonarr).
+ - type: checkboxes
+   attributes:
+-    label: Is there an existing issue for this?
+-    description: Please search to see if an open or closed issue already exists for the feature you are requesting. If a feature request exists and it is closed as complete it may not yet be in a stable release.
++    label: Scope check
+     options:
+-    - label: I have searched the existing open and closed issues
++    - label: This request is related to anime search efficiency, indexer compatibility, or fork infrastructure
++      required: true
++    - label: I have searched existing open and closed issues
+       required: true
+ - type: textarea
+   attributes:
+-    label: Is your feature request related to a problem? Please describe
+-    description: A clear and concise description of what the problem is.
+-  validations:
+-    required: true
+-- type: textarea
+-  attributes:
+-    label: Describe the solution you'd like
+-    description: A clear and concise description of what you want to happen.
++    label: Problem
++    description: What anime search problem does this address?
+   validations:
+     required: true
+ - type: textarea
+   attributes:
+-    label: Describe alternatives you've considered
+-    description: A clear and concise description of any alternative solutions or features you've considered.
++    label: Proposed solution
++    description: How should the fork handle this?
+   validations:
+     required: true
+ - type: textarea
+   attributes:
+-    label: Anything else?
+-    description: |
+-      Links? References? Mockups? Anything that will give us more context about the feature you are encountering!
+-      Tip: You can attach images or log files by clicking this area to highlight it and then dragging files in.
++    label: Alternatives considered
++    description: Other approaches you've thought about, or why upstream Sonarr doesn't solve this.
+   validations:
+     required: false
+diff --git a/.github/ISSUE_TEMPLATE/indexer_compatibility.yml b/.github/ISSUE_TEMPLATE/indexer_compatibility.yml
+new file mode 100644
+index 0000000000000000000000000000000000000000..ac730ee05bc9e0b99ca3b29ce282d1e0ccbee689
+--- /dev/null
++++ b/.github/ISSUE_TEMPLATE/indexer_compatibility.yml
+@@ -0,0 +1,86 @@
++name: Indexer Compatibility Report
++description: Report how an indexer behaves with the anime search cascade
++labels: ['indexer-compat']
++body:
++- type: markdown
++  attributes:
++    value: |
++      This form collects compatibility data for indexers beyond the tested baseline (native Nyaa).
++      Both success and failure reports are useful.
++- type: input
++  attributes:
++    label: Indexer name and type
++    description: "e.g. Nyaa (Torznab), AnimeTosho (Newznab), AniDex (Torznab)"
++    placeholder: "Indexer Name (protocol)"
++  validations:
++    required: true
++- type: dropdown
++  attributes:
++    label: Connection path
++    options:
++      - Native / built-in indexer
++      - Prowlarr / Torznab
++      - Prowlarr / Newznab
++      - Other
++  validations:
++    required: true
++- type: dropdown
++  attributes:
++    label: Public or private?
++    options:
++      - Public
++      - Private
++  validations:
++    required: true
++- type: input
++  attributes:
++    label: Fork version
++    placeholder: "4.0.17.812"
++  validations:
++    required: true
++- type: textarea
++  attributes:
++    label: Sample release titles
++    description: Paste a few release titles that worked or failed to match. This helps diagnose parser issues.
++    placeholder: |
++      Worked: [SubGroup] Series Name S01-S04 [1080p]
++      Failed: [SubGroup] Series.Name.Complete.BluRay.1080p
++  validations:
++    required: true
++- type: dropdown
++  attributes:
++    label: Did broad-first (pack) search happen?
++    description: In trace logs, was a broad title-only query sent before season-specific queries?
++    options:
++      - "Yes"
++      - "No"
++      - "Not sure"
++  validations:
++    required: true
++- type: dropdown
++  attributes:
++    label: Was pack coverage recognized?
++    description: Did the cascade skip per-episode queries after finding a pack release?
++    options:
++      - "Yes"
++      - "No"
++      - "Partially (some seasons skipped)"
++      - "Not sure"
++  validations:
++    required: true
++- type: dropdown
++  attributes:
++    label: Does behavior differ from native Nyaa baseline?
++    options:
++      - "Yes — worse (more queries, missed packs)"
++      - "Yes — different but acceptable"
++      - "No — same behavior"
++      - "Not sure / haven't compared"
++  validations:
++    required: true
++- type: textarea
++  attributes:
++    label: Additional context
++    description: Trace log excerpts, e2e test output, or any other details.
++  validations:
++    required: false
+diff --git a/.github/actions/archive/action.yml b/.github/actions/archive/action.yml
+index 83e8a8ea9eb8740dcbf66a3f9916f44cea9a092d..bfaee9f7961baf8d8fdb65a027256b7cbf30e013 100644
+--- a/.github/actions/archive/action.yml
++++ b/.github/actions/archive/action.yml
+@@ -25,5 +25,5 @@ runs:
+   using: 'composite'
+   steps:
+     - name: Archive Artifact
+-      uses: thedoctor0/zip-release@0.7.5
++      uses: thedoctor0/zip-release@7fddfdd07cadb5b8c6c0dbcdcec17f8cd7784b80 # 0.7.5
+       
+diff --git a/.github/actions/package/action.yml b/.github/actions/package/action.yml
+index 99c4d4ff1ac7ed0414ed348118bd5aa550beb7be..1e3b2641aeb723231bdff66ae82357643944ee73 100644
+--- a/.github/actions/package/action.yml
++++ b/.github/actions/package/action.yml
+@@ -17,21 +17,24 @@ inputs:
+   major_version:
+     description: 'Sonarr major version'
+     required: true
+-  version:
+-    description: 'Sonarr version'
++  app_version:
++    description: 'Sonarr app version'
++    required: true
++  release_version:
++    description: 'Sonarr fork release version'
+     required: true
+ 
+ runs:
+   using: 'composite'
+   steps:
+     - name: Download Artifact
+-      uses: actions/download-artifact@v4
++      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+       with:
+         name: ${{ inputs.artifact }}
+         path: _output
+-        
++
+     - name: Download UI Artifact
+-      uses: actions/download-artifact@v4
++      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+       with:
+         name: build_ui
+         path: _output/UI
+@@ -42,7 +45,8 @@ runs:
+         echo "FRAMEWORK=${{ inputs.framework }}" >> "$GITHUB_ENV"
+         echo "BRANCH=${{ inputs.branch }}" >> "$GITHUB_ENV"
+         echo "SONARR_MAJOR_VERSION=${{ inputs.major_version }}" >> "$GITHUB_ENV"
+-        echo "SONARR_VERSION=${{ inputs.version }}" >> "$GITHUB_ENV"
++        echo "APP_VERSION=${{ inputs.app_version }}" >> "$GITHUB_ENV"
++        echo "RELEASE_VERSION=${{ inputs.release_version }}" >> "$GITHUB_ENV"
+ 
+     - name: Create Packages
+       shell: bash
+@@ -67,11 +71,12 @@ runs:
+         build.bat
+ 
+     - name: Upload Artifact
+-      uses: actions/upload-artifact@v4
++      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+       with:
+         name: release_${{ inputs.platform }}
+         compression-level: 0
+         if-no-files-found: error
++        retention-days: 7
+         path: |
+           _artifacts/*.exe
+           _artifacts/*.tar.gz
+diff --git a/.github/actions/package/package.sh b/.github/actions/package/package.sh
+index 8dce605853393e4b9befd243bc2f3fcd6485abb9..258a4dffa12b14e5bb65404e9d5d33b3f53b852e 100755
+--- a/.github/actions/package/package.sh
++++ b/.github/actions/package/package.sh
+@@ -4,6 +4,7 @@ outputFolder=_output
+ artifactsFolder=_artifacts
+ uiFolder="$outputFolder/UI"
+ framework="${FRAMEWORK:=net6.0}"
++releaseVersion="${RELEASE_VERSION:-${APP_VERSION}}"
+ 
+ rm -rf $artifactsFolder
+ mkdir $artifactsFolder
+@@ -13,7 +14,7 @@ do
+   name="${runtime##*/}"
+   folderName="$runtime/$framework"
+   sonarrFolder="$folderName/Sonarr"
+-  archiveName="Sonarr.$BRANCH.$SONARR_VERSION.$name"
++  archiveName="Sonarr.$BRANCH.$releaseVersion.$name"
+ 
+   if [[ "$name" == 'UI' ]]; then
+     continue
+diff --git a/.github/actions/publish-test-artifact/action.yml b/.github/actions/publish-test-artifact/action.yml
+index af3642043018578d6731c62fa4e549578173272f..a9d57f8982ccfa3799c5f13c93eb15a08657f21b 100644
+--- a/.github/actions/publish-test-artifact/action.yml
++++ b/.github/actions/publish-test-artifact/action.yml
+@@ -12,7 +12,8 @@ inputs:
+ runs:
+   using: 'composite'
+   steps:
+-    - uses: actions/upload-artifact@v4
++    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+       with:
+         name: tests-${{ inputs.runtime }}
+         path: _tests/${{ inputs.framework }}/${{ inputs.runtime }}/publish/**/*
++        retention-days: 7
+diff --git a/.github/actions/test/action.yml b/.github/actions/test/action.yml
+index bd62f483054d9a09c4ca218e07c001baa3c72920..5b53e38027f7fdbedbd3916f774ef24d828a561f 100644
+--- a/.github/actions/test/action.yml
++++ b/.github/actions/test/action.yml
+@@ -27,11 +27,13 @@ runs:
+   using: 'composite'
+   steps:
+     - name: Setup .NET
+-      uses: actions/setup-dotnet@v4
++      uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
++      with:
++        dotnet-version: 6.0.428
+ 
+     - name: Setup Postgres
+       if: ${{ inputs.use_postgres }}
+-      uses: ikalnytskyi/action-setup-postgres@v4
++      uses: ikalnytskyi/action-setup-postgres@fd37e265ec6a48981d62fa415f1fafd03bfd261c # v4
+ 
+     - name: Setup Test Variables
+       shell: bash
+@@ -48,14 +50,14 @@ runs:
+         echo "Sonarr__Postgres__Password=postgres" >> "$GITHUB_ENV"
+ 
+     - name: Download Artifact
+-      uses: actions/download-artifact@v4
++      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+       with:
+         name: ${{ inputs.artifact }}
+         path: _tests
+ 
+     - name: Download Binary Artifact
+       if: ${{ inputs.integration_tests }}
+-      uses: actions/download-artifact@v4
++      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+       with:
+         name: ${{ inputs.binary_artifact }}
+         path: _output
+@@ -77,11 +79,12 @@ runs:
+ 
+     - name: Run tests
+       shell: bash
+-      run: dotnet test ./_tests/Sonarr.*.Test.dll --filter "${{ inputs.filter }}" --logger "trx;LogFileName=${{ env.RESULTS_NAME }}.trx" --logger "GitHubActions;summary.includePassedTests=true;summary.includeSkippedTests=true"
++      run: dotnet test ./_tests/Sonarr.*.Test.dll --filter "${{ inputs.filter }}" --logger "trx;LogFileName=${{ env.RESULTS_NAME }}.trx"
+ 
+     - name: Upload Test Results
+       if: ${{ !cancelled() }}
+-      uses: actions/upload-artifact@v4
++      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+       with:
+         name: results-${{ env.RESULTS_NAME }}
+         path: TestResults/*.trx
++        retention-days: 7
+diff --git a/.github/dependabot.yml b/.github/dependabot.yml
+deleted file mode 100644
+index f33a02cd16e48a11403f8a847d5f2fd282e1559a..0000000000000000000000000000000000000000
+--- a/.github/dependabot.yml
++++ /dev/null
+@@ -1,12 +0,0 @@
+-# To get started with Dependabot version updates, you'll need to specify which
+-# package ecosystems to update and where the package manifests are located.
+-# Please see the documentation for more information:
+-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+-# https://containers.dev/guide/dependabot
+-
+-version: 2
+-updates:
+- - package-ecosystem: "devcontainers"
+-   directory: "/"
+-   schedule:
+-     interval: weekly
+diff --git a/.github/workflows/api_docs.yml b/.github/workflows/api_docs.yml
+deleted file mode 100644
+index dfd8ce0e25929d24df72dbb93ab1c9d9fd4513b0..0000000000000000000000000000000000000000
+--- a/.github/workflows/api_docs.yml
++++ /dev/null
+@@ -1,52 +0,0 @@
+-name: 'API Docs'
+-
+-on:
+-  workflow_dispatch:
+-  schedule:
+-    - cron: '0 0 * * 1'
+-  push:
+-    branches:
+-      - develop
+-    paths:
+-      - ".github/workflows/api_docs.yml"
+-      - "docs.sh"
+-      - "src/Sonarr.Api.*/**"
+-      - "src/Sonarr.Http/**"
+-      - "src/**/*.csproj"
+-      - "src/*"
+-
+-concurrency:
+-  group: ${{ github.workflow }}-${{ github.ref }}
+-  cancel-in-progress: true
+-
+-jobs:
+-  api_docs:
+-    runs-on: ubuntu-latest
+-    if: github.repository == 'Sonarr/Sonarr'
+-    permissions:
+-      contents: write
+-    steps:
+-      - uses: actions/checkout@v4
+-
+-      - name: Setup dotnet
+-        uses: actions/setup-dotnet@v4
+-        id: setup-dotnet
+-
+-      - name: Create openapi.json
+-        run: ./docs.sh Linux
+-
+-      - name: Commit API Docs Change
+-        continue-on-error: true
+-        run: |
+-          git config --global user.email "development@sonarr.tv"
+-          git config --global user.name "Sonarr"
+-          git checkout -b api-docs
+-          git add src
+-          if git status | grep -q modified
+-          then
+-            git commit -am 'Automated API Docs update' -m "ignore-downstream"
+-            git push -f --set-upstream origin api-docs
+-            curl -X POST -H "Authorization: Bearer ${{ secrets.OPENAPI_PAT }}" -H "Accept: application/vnd.github+json" https://api.github.com/repos/sonarr/sonarr/pulls -d '{"head":"api-docs","base":"develop","title":"Update API docs"}'
+-          else
+-            echo "No changes since last run"
+-          fi
+diff --git a/.github/workflows/build.yml b/.github/workflows/build.yml
+index ac1573213f6acccaab09b0ff6a01bc79835c6b95..da40606f7abbea5f3e91c9685e092ce926058eaf 100644
+--- a/.github/workflows/build.yml
++++ b/.github/workflows/build.yml
+@@ -10,9 +10,14 @@ on:
+   pull_request:
+     branches:
+       - develop
++      - main
+     paths-ignore:
+       - "src/NzbDrone.Core/Localization/Core/**"
+       - "src/Sonarr.Api.*/openapi.json"
++  workflow_dispatch:
++
++permissions:
++  contents: read
+ 
+ concurrency:
+   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+@@ -22,7 +27,7 @@ env:
+   FRAMEWORK: net6.0
+   RAW_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+   SONARR_MAJOR_VERSION: 4
+-  VERSION: 4.0.17
++  UPSTREAM_VERSION: 4.0.17.2952
+ 
+ jobs:
+   backend:
+@@ -30,29 +35,33 @@ jobs:
+     outputs:
+       framework: ${{ steps.variables.outputs.framework }}
+       major_version: ${{ steps.variables.outputs.major_version }}
+-      version: ${{ steps.variables.outputs.version }}
++      app_version: ${{ steps.variables.outputs.app_version }}
+     steps:
+       - name: Check out
+-        uses: actions/checkout@v4
++        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
++        with:
++          persist-credentials: false
++          fetch-depth: 1
+ 
+       - name: Setup .NET
+-        uses: actions/setup-dotnet@v4
++        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
++        with:
++          dotnet-version: 6.0.100
+ 
+       - name: Setup Environment Variables
+         id: variables
+         shell: bash
+         run: |
+-          # Add 800 to the build number because GitHub won't let us pick an arbitrary starting point
+-          SONARR_VERSION="${{ env.VERSION }}.$((${{ github.run_number }}+800))"
++          APP_VERSION="${{ env.UPSTREAM_VERSION }}"
+           DOTNET_VERSION=$(jq -r '.sdk.version' global.json)
+ 
+           echo "SDK_PATH=${{ env.DOTNET_ROOT }}/sdk/${DOTNET_VERSION}" >> "$GITHUB_ENV"
+-          echo "SONARR_VERSION=$SONARR_VERSION" >> "$GITHUB_ENV"
++          echo "APP_VERSION=$APP_VERSION" >> "$GITHUB_ENV"
+           echo "BRANCH=${RAW_BRANCH_NAME//\//-}" >> "$GITHUB_ENV"
+ 
+           echo "framework=${{ env.FRAMEWORK }}" >> "$GITHUB_OUTPUT"
+           echo "major_version=${{ env.SONARR_MAJOR_VERSION }}" >> "$GITHUB_OUTPUT"
+-          echo "version=$SONARR_VERSION" >> "$GITHUB_OUTPUT"
++          echo "app_version=$APP_VERSION" >> "$GITHUB_OUTPUT"
+ 
+       - name: Enable Extra Platforms In SDK
+         shell: bash
+@@ -62,8 +71,6 @@ jobs:
+         shell: bash
+         run: ./build.sh --backend --enable-extra-platforms --packages
+ 
+-      # Test Artifacts
+-
+       - name: Publish win-x64 Test Artifact
+         uses: ./.github/actions/publish-test-artifact
+         with:
+@@ -82,37 +89,45 @@ jobs:
+           framework: ${{ env.FRAMEWORK }}
+           runtime: osx-arm64
+ 
+-      # Build Artifacts (grouped by OS)
+-
+       - name: Publish FreeBSD Artifact
+-        uses: actions/upload-artifact@v4
++        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+         with:
+           name: build_freebsd
+           path: _artifacts/freebsd-*/**/*
++          retention-days: 7
++
+       - name: Publish Linux Artifact
+-        uses: actions/upload-artifact@v4
++        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+         with:
+           name: build_linux
+           path: _artifacts/linux-*/**/*
++          retention-days: 7
++
+       - name: Publish macOS Artifact
+-        uses: actions/upload-artifact@v4
++        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+         with:
+           name: build_macos
+           path: _artifacts/osx-*/**/*
++          retention-days: 7
++
+       - name: Publish Windows Artifact
+-        uses: actions/upload-artifact@v4
++        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+         with:
+           name: build_windows
+           path: _artifacts/win-*/**/*
++          retention-days: 7
+ 
+   frontend:
+     runs-on: ubuntu-latest
+     steps:
+       - name: Check out
+-        uses: actions/checkout@v4
++        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
++        with:
++          persist-credentials: false
++          fetch-depth: 1
+ 
+       - name: Volta
+-        uses: volta-cli/action@v4
++        uses: volta-cli/action@5c175f92dea6f48441c436471e6479dbc192e194 # v4
+ 
+       - name: Yarn Install
+         run: yarn install
+@@ -127,10 +142,11 @@ jobs:
+         run: yarn build --env production
+ 
+       - name: Publish UI Artifact
+-        uses: actions/upload-artifact@v4
++        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+         with:
+           name: build_ui
+           path: _output/UI/**/*
++          retention-days: 7
+ 
+   unit_test:
+     needs: backend
+@@ -151,7 +167,10 @@ jobs:
+     runs-on: ${{ matrix.os }}
+     steps:
+       - name: Check out
+-        uses: actions/checkout@v4
++        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
++        with:
++          persist-credentials: false
++          fetch-depth: 1
+ 
+       - name: Test
+         uses: ./.github/actions/test
+@@ -166,7 +185,10 @@ jobs:
+     runs-on: ubuntu-latest
+     steps:
+       - name: Check out
+-        uses: actions/checkout@v4
++        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
++        with:
++          persist-credentials: false
++          fetch-depth: 1
+ 
+       - name: Test
+         uses: ./.github/actions/test
+@@ -202,7 +224,10 @@ jobs:
+     runs-on: ${{ matrix.os }}
+     steps:
+       - name: Check out
+-        uses: actions/checkout@v4
++        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
++        with:
++          persist-credentials: false
++          fetch-depth: 1
+ 
+       - name: Test
+         uses: ./.github/actions/test
+@@ -216,42 +241,15 @@ jobs:
+           binary_path: ${{ matrix.binary_path }}
+ 
+   deploy:
+-    if: ${{ github.ref_name == 'develop' || github.ref_name == 'main' }}
++    if: ${{ github.ref_name == 'main' }}
+     needs: [backend, frontend, unit_test, unit_test_postgres, integration_test]
++    permissions:
++      contents: write
++      packages: write
+     secrets: inherit
+-    uses: ./.github/workflows/deploy.yml
++    uses: ./.github/workflows/release.yml
+     with:
+       framework: ${{ needs.backend.outputs.framework }}
+       branch: ${{ github.ref_name }}
+       major_version: ${{ needs.backend.outputs.major_version }}
+-      version: ${{ needs.backend.outputs.version }}
+-
+-  notify:
+-    name: Discord Notification
+-    needs:
+-      [
+-        backend,
+-        frontend,
+-        unit_test,
+-        unit_test_postgres,
+-        integration_test,
+-        deploy,
+-      ]
+-    if: ${{ !cancelled() && (github.ref_name == 'develop' || github.ref_name == 'main') }}
+-    env:
+-      STATUS: ${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}
+-    runs-on: ubuntu-latest
+-
+-    steps:
+-      - name: Notify
+-        uses: tsickert/discord-webhook@v6.0.0
+-        with:
+-          webhook-url: ${{ secrets.DISCORD_WEBHOOK_URL }}
+-          username: "GitHub Actions"
+-          avatar-url: "https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png"
+-          embed-title: "${{ github.workflow }}: ${{ env.STATUS == 'success' && 'Success' || 'Failure' }}"
+-          embed-url: "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+-          embed-description: |
+-            **Branch** ${{ github.ref }}
+-            **Build** ${{ needs.backend.outputs.version }}
+-          embed-color: ${{ env.STATUS == 'success' && '3066993' || '15158332' }}
++      app_version: ${{ needs.backend.outputs.app_version }}
+diff --git a/.github/workflows/conflict_labeler.yml b/.github/workflows/conflict_labeler.yml
+deleted file mode 100644
+index e9afb71a3d0f1c8e313d5f4f7a951e2a5b6888db..0000000000000000000000000000000000000000
+--- a/.github/workflows/conflict_labeler.yml
++++ /dev/null
+@@ -1,26 +0,0 @@
+-name: Merge Conflict Labeler
+-
+-on:
+-  push:
+-    branches:
+-      - develop
+-  pull_request_target:
+-    branches:
+-      - develop
+-    types: [synchronize]
+-
+-jobs:
+-  label:
+-    name: Labeling
+-    runs-on: ubuntu-latest
+-    if: ${{ github.repository == 'Sonarr/Sonarr' }}
+-    permissions:
+-      contents: read
+-      pull-requests: write
+-    steps:
+-      - name: Apply label
+-        uses: eps1lon/actions-label-merge-conflict@v3
+-        with:
+-          dirtyLabel: 'merge-conflict'
+-          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+-          
+\ No newline at end of file
+diff --git a/.github/workflows/deploy.yml b/.github/workflows/deploy.yml
+deleted file mode 100644
+index 4fa5b54ee366b12e75d50c0fd34f289b662e2380..0000000000000000000000000000000000000000
+--- a/.github/workflows/deploy.yml
++++ /dev/null
+@@ -1,160 +0,0 @@
+-name: Deploy
+-
+-on:
+-  workflow_call:
+-    inputs:
+-      framework: 
+-        description: '.net framework'
+-        type: string
+-        required: true
+-      branch:
+-        description: 'Git branch used for this build'
+-        type: string
+-        required: true
+-      major_version:
+-        description: 'Sonarr major version'
+-        type: string
+-        required: true
+-      version:
+-        description: 'Sonarr version'
+-        type: string
+-        required: true
+-    secrets:
+-      SERVICES_API_KEY:
+-        required: true
+-
+-jobs:
+-  package:
+-    strategy:
+-      matrix:
+-        platform: [freebsd, linux, macos, windows]
+-        include:
+-          - platform: freebsd
+-            os: ubuntu-latest
+-          - platform: linux
+-            os: ubuntu-latest
+-          - platform: macos
+-            os: ubuntu-latest
+-          - platform: windows
+-            os: windows-latest
+-
+-    runs-on: ${{ matrix.os }}
+-    steps:
+-    - name: Check out
+-      uses: actions/checkout@v4
+-
+-    - name: Package
+-      uses: ./.github/actions/package
+-      with:
+-        framework: ${{ inputs.framework }}
+-        platform: ${{ matrix.platform }}
+-        artifact: build_${{ matrix.platform }}
+-        branch: ${{ inputs.branch }}
+-        major_version: ${{ inputs.major_version }}
+-        version: ${{ inputs.version }}
+-
+-  release:
+-    needs: package
+-    runs-on: ubuntu-latest
+-    permissions:
+-      contents: write
+-    steps:
+-    - name: Check out
+-      uses: actions/checkout@v4
+-
+-    - name: Download release artifacts
+-      uses: actions/download-artifact@v4
+-      with:
+-        path: _artifacts
+-        pattern: release_*
+-        merge-multiple: true
+-
+-    - name: Get Previous Release
+-      id: previous-release
+-      uses: cardinalby/git-get-release-action@v1
+-      env:
+-        GITHUB_TOKEN: ${{ github.token }}
+-      with:
+-        latest: true
+-        prerelease: ${{ inputs.branch != 'main' }}
+-
+-    - name: Generate Release Notes
+-      id: generate-release-notes
+-      uses: actions/github-script@v7
+-      with:
+-        github-token: ${{ github.token }}
+-        result-encoding: string
+-        script: |
+-          const { data } = await github.rest.repos.generateReleaseNotes({
+-            owner: context.repo.owner,
+-            repo: context.repo.repo,
+-            tag_name: 'v${{ inputs.version }}',
+-            target_commitish: '${{ github.sha }}',
+-            previous_tag_name: '${{ steps.previous-release.outputs.tag_name }}',
+-          })
+-          return data.body
+-
+-    - name: Create release
+-      uses: ncipollo/release-action@v1
+-      with:
+-        artifacts: _artifacts/Sonarr.*
+-        commit: ${{ github.sha }}
+-        generateReleaseNotes: false
+-        body: ${{ steps.generate-release-notes.outputs.result }}
+-        name: ${{ inputs.version }}
+-        prerelease: ${{ inputs.branch != 'main' }}
+-        skipIfReleaseExists: true
+-        tag: v${{ inputs.version }}
+-
+-    - name: Publish to Services
+-      shell: bash
+-      working-directory: _artifacts
+-      run: |
+-        branch=${{ inputs.branch }}
+-        version=${{ inputs.version }}
+-        lastCommit=${{ github.sha }}
+-        
+-        hashes="["
+-        
+-        addHash() {
+-          path=$1
+-          os=$2
+-          arch=$3
+-          type=$4
+-        
+-          local hash=$(sha256sum *.$version.$path | awk '{ print $1; }')
+-          echo "{ \""Os\"": \""$os\"", \""Arch\"": \""$arch\"", \""Type\"": \""$type\"", \""Hash\"": \""$hash\"" }"
+-        }
+-        
+-        hashes="$hashes $(addHash "linux-arm.tar.gz" "linux" "arm" "archive")"
+-        hashes="$hashes, $(addHash "linux-arm64.tar.gz" "linux" "arm64" "archive")"
+-        hashes="$hashes, $(addHash "linux-x64.tar.gz" "linux" "x64" "archive")"
+-        # hashes="$hashes, $(addHash "linux-x86.tar.gz" "linux" "x86" "archive")"
+-        
+-        # hashes="$hashes, $(addHash "linux-musl-arm.tar.gz" "linuxmusl" "arm" "archive")"
+-        hashes="$hashes, $(addHash "linux-musl-arm64.tar.gz" "linuxmusl" "arm64" "archive")"
+-        hashes="$hashes, $(addHash "linux-musl-x64.tar.gz" "linuxmusl" "x64" "archive")"
+-        
+-        hashes="$hashes, $(addHash "osx-arm64.tar.gz" "osx" "arm64" "archive")"
+-        hashes="$hashes, $(addHash "osx-x64.tar.gz" "osx" "x64" "archive")"
+-        
+-        hashes="$hashes, $(addHash "osx-arm64-app.zip" "osx" "arm64" "installer")"
+-        hashes="$hashes, $(addHash "osx-x64-app.zip" "osx" "x64" "installer")"
+-        
+-        hashes="$hashes, $(addHash "win-x64.zip" "windows" "x64" "archive")"
+-        hashes="$hashes, $(addHash "win-x86.zip" "windows" "x86" "archive")"
+-        
+-        hashes="$hashes, $(addHash "win-x64-installer.exe" "windows" "x64" "installer")"
+-        hashes="$hashes, $(addHash "win-x86-installer.exe" "windows" "x86" "installer")"
+-        
+-        hashes="$hashes, $(addHash "freebsd-x64.tar.gz" "freebsd" "x64" "archive")"
+-        
+-        hashes="$hashes ]"
+-        
+-        json="{\""branch\"":\""$branch\"", \""version\"":\""$version\"", \""lastCommit\"":\""$lastCommit\"", \""hashes\"":$hashes, \""gitHubRelease\"":true}"
+-        url="https://services.sonarr.tv/v1/update"
+-        
+-        echo "Publishing update $version ($branch) to: $url"
+-        echo "$json"
+-        
+-        curl -H "Content-Type: application/json" -H "X-Api-Key: ${{ secrets.SERVICES_API_KEY }}" -X POST -d "$json" --fail-with-body $url
+diff --git a/.github/workflows/labeler.yml b/.github/workflows/labeler.yml
+deleted file mode 100644
+index df54c0fff5acbafe2aebeda7ba54f0b84cec801d..0000000000000000000000000000000000000000
+--- a/.github/workflows/labeler.yml
++++ /dev/null
+@@ -1,13 +0,0 @@
+-name: "Pull Request Labeler"
+-on:
+-  - pull_request_target
+-
+-jobs:
+-  triage:
+-    permissions:
+-      contents: read
+-      pull-requests: write
+-    runs-on: ubuntu-latest
+-    if: github.repository == 'Sonarr/Sonarr'
+-    steps:
+-      - uses: actions/labeler@v5
+diff --git a/.github/workflows/lock.yml b/.github/workflows/lock.yml
+deleted file mode 100644
+index d775234db998d0be940a885d7216f4e30a2fee5b..0000000000000000000000000000000000000000
+--- a/.github/workflows/lock.yml
++++ /dev/null
+@@ -1,22 +0,0 @@
+-name: 'Lock threads'
+-
+-on:
+-  workflow_dispatch:
+-  schedule:
+-    - cron: '0 0 * * *'
+-
+-jobs:
+-  lock:
+-    runs-on: ubuntu-latest
+-    if: github.repository == 'Sonarr/Sonarr'
+-    steps:
+-      - uses: dessant/lock-threads@v5
+-        with:
+-          github-token: ${{ github.token }}
+-          issue-inactive-days: '90'
+-          exclude-issue-created-before: ''
+-          exclude-any-issue-labels: 'one-day-maybe'
+-          add-issue-labels: ''
+-          issue-comment: ''
+-          issue-lock-reason: 'resolved'
+-          process-only: ''
+diff --git a/.github/workflows/release.yml b/.github/workflows/release.yml
+new file mode 100644
+index 0000000000000000000000000000000000000000..33856643da3cbe26a4ea0f3ce55fe0a8a915244c
+--- /dev/null
++++ b/.github/workflows/release.yml
+@@ -0,0 +1,279 @@
++name: Release
++
++on:
++  workflow_call:
++    inputs:
++      framework:
++        description: ".net framework"
++        required: true
++        type: string
++      branch:
++        description: "Git branch used for this build"
++        required: true
++        type: string
++      major_version:
++        description: "Sonarr major version"
++        required: true
++        type: string
++      app_version:
++        description: "Sonarr app version"
++        required: true
++        type: string
++    secrets:
++      GHCR_TOKEN:
++        required: false
++
++permissions:
++  contents: write
++  packages: write
++
++jobs:
++  resolve_version:
++    runs-on: ubuntu-latest
++    outputs:
++      release_version: ${{ steps.version.outputs.release_version }}
++
++    steps:
++      - name: Resolve Release Version
++        id: version
++        env:
++          APP_VERSION: ${{ inputs.app_version }}
++          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
++        shell: bash
++        run: |
++          set -euo pipefail
++
++          pattern="^v${APP_VERSION//./\\.}-anime\\.([0-9]+)$"
++          release_version=""
++          max_suffix=0
++
++          while IFS=$'\t' read -r tag_name target_commitish; do
++            if [[ -z "$tag_name" ]]; then
++              continue
++            fi
++
++            if [[ "$tag_name" =~ $pattern ]]; then
++              suffix="${BASH_REMATCH[1]}"
++
++              if (( suffix > max_suffix )); then
++                max_suffix=$suffix
++              fi
++
++              if [[ "$target_commitish" == "$GITHUB_SHA" ]]; then
++                release_version="${tag_name#v}"
++              fi
++            fi
++          done < <(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases?per_page=100" --jq '.[] | [.tag_name, .target_commitish] | @tsv')
++
++          if [[ -z "$release_version" ]]; then
++            release_version="${APP_VERSION}-anime.$((max_suffix + 1))"
++          fi
++
++          echo "release_version=$release_version" >> "$GITHUB_OUTPUT"
++
++  package:
++    needs: resolve_version
++    strategy:
++      matrix:
++        platform: [freebsd, linux, macos, windows]
++        include:
++          - platform: freebsd
++            os: ubuntu-latest
++          - platform: linux
++            os: ubuntu-latest
++          - platform: macos
++            os: ubuntu-latest
++          - platform: windows
++            os: windows-latest
++
++    runs-on: ${{ matrix.os }}
++
++    steps:
++      - name: Check out
++        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
++        with:
++          persist-credentials: false
++          fetch-depth: 1
++
++      - name: Package
++        uses: ./.github/actions/package
++        with:
++          framework: ${{ inputs.framework }}
++          platform: ${{ matrix.platform }}
++          artifact: build_${{ matrix.platform }}
++          branch: ${{ inputs.branch }}
++          major_version: ${{ inputs.major_version }}
++          app_version: ${{ inputs.app_version }}
++          release_version: ${{ needs.resolve_version.outputs.release_version }}
++
++  docker:
++    needs: [resolve_version, package]
++    runs-on: ubuntu-latest
++
++    steps:
++      - name: Check out
++        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
++        with:
++          persist-credentials: false
++          fetch-depth: 1
++
++      - name: Download Linux Artifact
++        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
++        with:
++          name: build_linux
++          path: _output
++
++      - name: Download UI Artifact
++        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
++        with:
++          name: build_ui
++          path: _output/UI
++
++      - name: Stage Docker Context
++        shell: bash
++        run: |
++          for mapping in "amd64:linux-x64" "arm64:linux-arm64"; do
++            IFS=":" read -r arch runtime <<< "$mapping"
++            target_dir="Sonarr-$arch"
++            runtime_dir="_output/$runtime/${{ inputs.framework }}/Sonarr"
++
++            rm -rf "$target_dir"
++            mkdir -p "$target_dir"
++            cp -R "$runtime_dir"/. "$target_dir"/
++            cp -R _output/UI "$target_dir"/UI
++          done
++
++          find Sonarr-amd64 Sonarr-arm64 \( -name "ffprobe" -o -name "Sonarr" -o -name "Sonarr.Update" \) -exec chmod a+x {} \;
++
++      - name: Set up QEMU
++        uses: docker/setup-qemu-action@v3
++
++      - name: Set up Docker Buildx
++        uses: docker/setup-buildx-action@v3
++
++      - name: Log in to GHCR
++        uses: docker/login-action@v3
++        with:
++          registry: ghcr.io
++          username: ${{ github.repository_owner }}
++          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
++
++      - name: Compute Image Name
++        id: image
++        shell: bash
++        run: |
++          echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
++
++      - name: Build and Push Docker Image
++        uses: docker/build-push-action@v6
++        with:
++          context: .
++          file: ./Dockerfile.release
++          platforms: linux/amd64,linux/arm64
++          push: true
++          tags: |
++            ${{ steps.image.outputs.name }}:${{ needs.resolve_version.outputs.release_version }}
++          labels: |
++            org.opencontainers.image.title=sonarr-anime
++            org.opencontainers.image.description=Anime-focused Sonarr builds
++            org.opencontainers.image.url=https://github.com/${{ github.repository }}
++            org.opencontainers.image.source=https://github.com/${{ github.repository }}
++            org.opencontainers.image.version=${{ needs.resolve_version.outputs.release_version }}
++            org.opencontainers.image.revision=${{ github.sha }}
++
++  release:
++    needs: [resolve_version, package, docker]
++    runs-on: ubuntu-latest
++
++    steps:
++      - name: Download Release Artifacts
++        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
++        with:
++          path: _artifacts
++          pattern: release_*
++          merge-multiple: true
++
++      - name: Create Release
++        env:
++          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
++          APP_VERSION: ${{ inputs.app_version }}
++          RELEASE_VERSION: ${{ needs.resolve_version.outputs.release_version }}
++          RELEASE_TAG: v${{ needs.resolve_version.outputs.release_version }}
++        shell: bash
++        run: |
++          if gh release view "$RELEASE_TAG" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
++            echo "Release $RELEASE_TAG already exists, skipping."
++            exit 0
++          fi
++
++          gh release create "$RELEASE_TAG" _artifacts/Sonarr.* \
++            --repo "${GITHUB_REPOSITORY}" \
++            --title "$RELEASE_VERSION" \
++            --notes "Automated release for $RELEASE_VERSION (app version $APP_VERSION)." \
++            --target "${GITHUB_SHA}"
++
++  publish_latest:
++    needs: [resolve_version, docker, release]
++    runs-on: ubuntu-latest
++
++    steps:
++      - name: Set up Docker Buildx
++        uses: docker/setup-buildx-action@v3
++
++      - name: Log in to GHCR
++        uses: docker/login-action@v3
++        with:
++          registry: ghcr.io
++          username: ${{ github.repository_owner }}
++          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
++
++      - name: Compute Image Name
++        id: image
++        shell: bash
++        run: |
++          echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
++
++      - name: Publish Latest Tag
++        shell: bash
++        run: |
++          docker buildx imagetools create \
++            --tag "${{ steps.image.outputs.name }}:latest" \
++            "${{ steps.image.outputs.name }}:${{ needs.resolve_version.outputs.release_version }}"
++
++  verify_release:
++    needs: [resolve_version, docker, release, publish_latest]
++    runs-on: ubuntu-latest
++
++    steps:
++      - name: Set up Docker Buildx
++        uses: docker/setup-buildx-action@v3
++
++      - name: Log in to GHCR
++        uses: docker/login-action@v3
++        with:
++          registry: ghcr.io
++          username: ${{ github.repository_owner }}
++          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
++
++      - name: Compute Image Name
++        id: image
++        shell: bash
++        run: |
++          echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
++
++      - name: Verify Release and Images
++        env:
++          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
++          IMAGE_NAME: ${{ steps.image.outputs.name }}
++          RELEASE_VERSION: ${{ needs.resolve_version.outputs.release_version }}
++        shell: bash
++        run: |
++          set -euo pipefail
++
++          gh release view "v$RELEASE_VERSION" --repo "${GITHUB_REPOSITORY}" >/dev/null
++          version_digest="$(docker buildx imagetools inspect "$IMAGE_NAME:$RELEASE_VERSION" | sed -n 's/^Digest:[[:space:]]*//p' | head -n 1)"
++          latest_digest="$(docker buildx imagetools inspect "$IMAGE_NAME:latest" | sed -n 's/^Digest:[[:space:]]*//p' | head -n 1)"
++
++          test -n "$version_digest"
++          test -n "$latest_digest"
++          test "$version_digest" = "$latest_digest"
+diff --git a/.github/workflows/repair-latest.yml b/.github/workflows/repair-latest.yml
+new file mode 100644
+index 0000000000000000000000000000000000000000..c6c59fd978aff38e808e7c03ce176570e9c7b872
+--- /dev/null
++++ b/.github/workflows/repair-latest.yml
+@@ -0,0 +1,87 @@
++name: Repair Latest Image Tag
++
++on:
++  workflow_dispatch:
++    inputs:
++      release_version:
++        description: "Released image tag to promote to latest"
++        required: true
++        type: string
++
++permissions:
++  contents: read
++  packages: write
++
++jobs:
++  repair_latest:
++    runs-on: ubuntu-latest
++
++    steps:
++      - name: Set up Docker Buildx
++        uses: docker/setup-buildx-action@v3
++
++      - name: Log in to GHCR
++        uses: docker/login-action@v3
++        with:
++          registry: ghcr.io
++          username: ${{ github.repository_owner }}
++          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
++
++      - name: Compute Image Name
++        id: image
++        shell: bash
++        run: |
++          echo "name=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_OUTPUT"
++
++      - name: Verify Release Exists
++        env:
++          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
++          RELEASE_VERSION: ${{ inputs.release_version }}
++        shell: bash
++        run: |
++          set -euo pipefail
++          gh release view "v$RELEASE_VERSION" --repo "${GITHUB_REPOSITORY}" >/dev/null
++
++      - name: Verify Versioned Image Exists
++        env:
++          IMAGE_NAME: ${{ steps.image.outputs.name }}
++          RELEASE_VERSION: ${{ inputs.release_version }}
++        shell: bash
++        run: |
++          set -euo pipefail
++          docker buildx imagetools inspect "$IMAGE_NAME:$RELEASE_VERSION" >/dev/null
++
++      - name: Promote Latest Tag
++        env:
++          IMAGE_NAME: ${{ steps.image.outputs.name }}
++          RELEASE_VERSION: ${{ inputs.release_version }}
++        shell: bash
++        run: |
++          set -euo pipefail
++          docker buildx imagetools create \
++            --tag "$IMAGE_NAME:latest" \
++            "$IMAGE_NAME:$RELEASE_VERSION"
++
++      - name: Summarize Promotion
++        env:
++          IMAGE_NAME: ${{ steps.image.outputs.name }}
++          RELEASE_VERSION: ${{ inputs.release_version }}
++        shell: bash
++        run: |
++          set -euo pipefail
++
++          source_digest="$(docker buildx imagetools inspect "$IMAGE_NAME:$RELEASE_VERSION" | sed -n 's/^Digest:[[:space:]]*//p' | head -n 1)"
++          latest_digest="$(docker buildx imagetools inspect "$IMAGE_NAME:latest" | sed -n 's/^Digest:[[:space:]]*//p' | head -n 1)"
++
++          test -n "$source_digest"
++          test -n "$latest_digest"
++          test "$source_digest" = "$latest_digest"
++
++          {
++            echo "## Latest Tag Repair"
++            echo
++            echo "- Source image: \`$IMAGE_NAME:$RELEASE_VERSION\`"
++            echo "- Source digest: \`${source_digest:-unknown}\`"
++            echo "- Latest image: \`$IMAGE_NAME:latest\`"
++            echo "- Latest digest: \`${latest_digest:-unknown}\`"
++          } >> "$GITHUB_STEP_SUMMARY"
+diff --git a/.github/workflows/support-requests.yml b/.github/workflows/support-requests.yml
+deleted file mode 100644
+index adf5a8c4a0f2ea6c0a34fa62d9a7e3a21a150014..0000000000000000000000000000000000000000
+--- a/.github/workflows/support-requests.yml
++++ /dev/null
+@@ -1,29 +0,0 @@
+-name: 'Support Requests'
+-
+-on:
+-  issues:
+-    types: [labeled, unlabeled, reopened]
+-
+-permissions:
+-  issues: write
+-
+-jobs:
+-  action:
+-    runs-on: ubuntu-latest
+-    if: github.repository == 'Sonarr/Sonarr'
+-    steps:
+-      - uses: dessant/support-requests@v4
+-        with:
+-          github-token: ${{ github.token }}
+-          support-label: 'support'
+-          issue-comment: >
+-            :wave: @{issue-author}, we use the issue tracker exclusively
+-            for bug reports and feature requests. However, this issue appears
+-            to be a support request. Please use one of the support channels: 
+-            [forums](https://forums.sonarr.tv/), [subreddit](https://www.reddit.com/r/sonarr/), 
+-            [discord](https://discord.gg/Ex7FmFK), or [IRC](https://web.libera.chat/?channels=#sonarr) 
+-            for support/questions.
+-          close-issue: true
+-          issue-close-reason: 'not planned'
+-          lock-issue: false
+-          issue-lock-reason: 'off-topic'
+diff --git a/.gitignore b/.gitignore
+index d17209556c8e83ed6325dc69ab706627c1841802..0bce041cd7f7ce6b9484eec7d1147db7a1c13827 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -165,3 +165,27 @@ src/.idea/
+ 
+ # Ignore Jetbrains IntelliJ Workspace Directories
+ .idea/
++
++# Local assistant tooling
++.claude/
++.agents/
++.codex/
++AGENTS.md
++docs/IMPLEMENTATION.md
++CLAUDE.md
++
++# Local Docker testing
++local-test/config/
++local-test/tv/
++local-test/prowlarr-config/
++Sonarr/
++docker-context/
++
++# Trace and debug logs (beyond *.log above)
++*.trace*.txt
++*.debug*.txt
++
++# Databases
++*.db
++*.db-shm
++*.db-wal
+diff --git a/CONTRIBUTING.md b/CONTRIBUTING.md
+index 9eedd495b76ebf8ef4d5a2467837d8fade205929..29b9ccee36bf795eedb541355dd2756feaae15cf 100644
+--- a/CONTRIBUTING.md
++++ b/CONTRIBUTING.md
+@@ -1,48 +1,89 @@
+-# How to Contribute #
++# Contributing to sonarr-anime
+ 
+-We're always looking for people to help make Sonarr even better, there are a number of ways to contribute.
++This is a **minimal Sonarr v4 fork** focused exclusively on anime search efficiency. Contributions are welcome, but must stay within the fork's narrow scope.
+ 
+-## Documentation ##
+-Setup guides, [FAQ](https://wiki.servarr.com/sonarr/faq), the more information we have on the [wiki](https://wiki.servarr.com/sonarr) the better.
++## Principles
+ 
+-## Development ##
++- **Minimal diff** — touch as few files as possible. Prefer modifying existing methods over adding new ones
++- **Surgical changes** — no cosmetic changes to upstream code (formatting, renames, reordering). Never refactor upstream code "while you're in there"
++- **Simple logic** — straightforward conditionals over clever abstractions. Anyone reading the code should understand the anime-specific logic immediately
++- **No scope creep** — if a change doesn't reduce redundant anime search queries or support that goal, it doesn't belong here
+ 
+-### Tools required ###
+-- Visual Studio 2019 or higher (https://www.visualstudio.com/vs/).  The community version is free and works (https://www.visualstudio.com/downloads/).
+-- HTML/Javascript editor of choice (VS Code/Sublime Text/Webstorm/Atom/etc)
+-- [Git](https://git-scm.com/downloads)
+-- [NodeJS](https://nodejs.org/en/download/) (Node 10.X.X or higher)
++## Branch model
++
++- `main` is the release branch, based on upstream Sonarr v4
++- Feature branches should be created from `main`
++- PRs target `main`
++- Upstream rebases from `Sonarr/Sonarr` are done manually when needed
++
++## Development setup
++
++### Tools required
++
++- [.NET 6 SDK](https://dotnet.microsoft.com/download)
++- [Node.js](https://nodejs.org/) (see `volta` config in `package.json`)
+ - [Yarn](https://yarnpkg.com/)
++- [Git](https://git-scm.com/)
++- [Docker](https://www.docker.com/) (for e2e testing)
++
++### Build
++
++```bash
++# Full build (backend + frontend)
++./build.sh --backend --frontend
++
++# Backend only (faster iteration)
++dotnet build src/Sonarr.sln -p:TreatWarningsAsErrors=false --no-restore
++```
++
++Do not use `--packages` — it tries to create Windows packages and fails on macOS/Linux.
++
++### Test
++
++```bash
++# Full unit suite (build first, then test against _tests/ DLLs)
++dotnet test _tests/net6.0/Sonarr.Core.Test.dll \
++  --filter "Category!=ManualTest&Category!=IntegrationTest&Category!=AutomationTest"
++
++# Targeted test run
++dotnet test _tests/net6.0/Sonarr.Core.Test.dll \
++  --filter "FullyQualifiedName~SomeFixture"
++```
++
++Do not run `dotnet test` against `src/*.csproj` directly — SA1200 warnings treated as errors block that path.
++
++### End-to-end testing
++
++Any PR that changes the search pipeline **must** include e2e verification:
++
++```bash
++# Direct baseline
++/test-e2e "Example Series" S01-S04
++
++# Aggregator-backed path
++/test-e2e-prowlarr "Example Series" S01-S04 --indexer <supported-backend>
++```
++
++Both produce structured pass/fail reports. A feature is not complete until the e2e report confirms expected behavior.
++
++## Pull request guidelines
++
++- One logical change per PR
++- Keep the diff small — if your PR touches more than 3-4 files, consider whether it can be split
++- Include e2e test results for search-path changes
++- PRs that only touch docs, workflows, or test infrastructure do not need e2e verification but should pass CI
++
++## Code style
++
++Follow Sonarr's conventions exactly:
++- C# with 4-space indentation
++- Unix line endings (LF)
++- Match surrounding code style — do not introduce new patterns
++
++## What belongs upstream
++
++If your change improves Sonarr for all users (not just anime), consider contributing it to [Sonarr/Sonarr](https://github.com/Sonarr/Sonarr) instead. This fork is intentionally narrow.
++
++## Questions
+ 
+-### Getting started ###
+-
+-1. Fork Sonarr
+-2. Clone the repository into your development machine. [*info*](https://docs.github.com/en/get-started/quickstart/fork-a-repo)
+-3. Install the required Node Packages `yarn install`
+-4. Start webpack to monitor your dev environment for any frontend changes that need post processing using `yarn start` command.
+-5. Build the project in Visual Studio, Setting startup project to `Sonarr.Console` and framework to `x86`
+-6. Debug the project in Visual Studio
+-7. Open http://localhost:8989
+-
+-### Contributing Code ###
+-- If you're adding a new, already requested feature, please comment on [Github Issues](https://github.com/Sonarr/Sonarr/issues "Github Issues") so work is not duplicated (If you want to add something not already on there, please talk to us first)
+-- Rebase from Sonarr's `develop` branch, don't merge
+-- Make meaningful commits, or squash them
+-- Feel free to make a pull request before work is complete, this will let us see where its at and make comments/suggest improvements
+-- Reach out to us on our [forums](https://forums.sonarr.tv/), [subreddit](https://www.reddit.com/r/sonarr/), [discord](https://discord.gg/Ex7FmFK), or [IRC](https://web.libera.chat/?channels=#sonarr) if you have any questions
+-- Add tests (unit/integration)
+-- Commit with *nix line endings for consistency (We checkout Windows and commit *nix)
+-- One feature/bug fix per pull request to keep things clean and easy to understand
+-- Use 4 spaces instead of tabs, this should be the default for VS 2019 and WebStorm
+-
+-### Pull Requesting ###
+-- Only make pull requests to develop (currently `develop`), never `main`, if you make a PR to master we'll comment on it and close it
+-- You're probably going to get some comments or questions from us, they will be to ensure consistency and maintainability
+-- We'll try to respond to pull requests as soon as possible, if its been a day or two, please reach out to us, we may have missed it
+-- Each PR should come from its own [feature branch](http://martinfowler.com/bliki/FeatureBranch.html) not develop in your fork, it should have a meaningful branch name (what is being added/fixed)
+-  - new-feature (Good)
+-  - fix-bug (Good)
+-  - patch (Bad)
+-  - develop (Bad)
+-
+-If you have any questions about any of this, please let us know.
++Open an issue or start a discussion in the repository. For general Sonarr questions unrelated to this fork, use the [upstream Sonarr community](https://wiki.servarr.com/sonarr).
+diff --git a/Dockerfile b/Dockerfile
+new file mode 100644
+index 0000000000000000000000000000000000000000..84de14f8914eef7f263ae05ce2ba4fe9b15c0878
+--- /dev/null
++++ b/Dockerfile
+@@ -0,0 +1,12 @@
++FROM mcr.microsoft.com/dotnet/runtime:6.0-jammy
++
++RUN apt-get update && apt-get install -y libsqlite3-0 libicu70 && rm -rf /var/lib/apt/lists/*
++
++WORKDIR /opt/sonarr
++
++COPY Sonarr/ .
++
++VOLUME /config /tv
++EXPOSE 8989
++
++ENTRYPOINT ["./Sonarr", "-nobrowser", "-data=/config"]
+diff --git a/Dockerfile.release b/Dockerfile.release
+new file mode 100644
+index 0000000000000000000000000000000000000000..9b84b6bc113a65e1de50642fc9682fb3a8cdfed1
+--- /dev/null
++++ b/Dockerfile.release
+@@ -0,0 +1,14 @@
++FROM mcr.microsoft.com/dotnet/runtime:6.0-jammy
++
++ARG TARGETARCH
++
++RUN apt-get update && apt-get install -y libsqlite3-0 libicu70 && rm -rf /var/lib/apt/lists/*
++
++WORKDIR /opt/sonarr
++
++COPY Sonarr-${TARGETARCH}/ .
++
++VOLUME /config /tv /downloads
++EXPOSE 8989
++
++ENTRYPOINT ["./Sonarr", "-nobrowser", "-data=/config"]
+diff --git a/README.md b/README.md
+index d43366f93602498d9d0c626271435553ca454355..df5755cb0ab9813c913f95fb6d4ffee8ce3f1b38 100644
+--- a/README.md
++++ b/README.md
+@@ -1,85 +1,184 @@
+-# <img width="24px" src="./Logo/256.png" alt="Sonarr"></img> Sonarr
++# sonarr-anime
+ 
+-[![Translated](https://translate.servarr.com/widget/servarr/sonarr/svg-badge.svg)](https://translate.servarr.com/engage/servarr/)
+-[![Backers on Open Collective](https://opencollective.com/Sonarr/backers/badge.svg)](#backers)
+-[![Sponsors on Open Collective](https://opencollective.com/Sonarr/sponsors/badge.svg)](#sponsors)
+-[![Mega Sponsors on Open Collective](https://opencollective.com/Sonarr/megasponsors/badge.svg)](#mega-sponsors)
++[![Build](https://github.com/RemingtonDev/sonarr-anime/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/RemingtonDev/sonarr-anime/actions/workflows/build.yml)
++[![GitHub Release](https://img.shields.io/github/v/release/RemingtonDev/sonarr-anime)](https://github.com/RemingtonDev/sonarr-anime/releases/latest)
++[![GHCR Image](https://img.shields.io/badge/ghcr.io-sonarr--anime-blue)](https://github.com/RemingtonDev/sonarr-anime/pkgs/container/sonarr-anime)
+ 
+-Sonarr is a PVR for Usenet and BitTorrent users. It can monitor multiple RSS feeds for new episodes of your favorite shows and will grab, sort and rename them. It can also be configured to automatically upgrade the quality of files already downloaded when a better quality format becomes available.
++A minimal [Sonarr](https://github.com/Sonarr/Sonarr) v4 fork focused on reducing redundant anime search queries. It patches the search pipeline to try pack search first, season search second, and per-episode only as a last resort.
+ 
+-## Getting Started
++## What this fork does
+ 
+-- [Download/Installation](https://sonarr.tv/#downloads-v3)
+-- [FAQ](https://wiki.servarr.com/sonarr/faq)
+-- [Wiki](https://wiki.servarr.com/Sonarr)
+-- [v4 Beta API Documentation](https://sonarr.tv/docs/api)
+-- [Donate](https://sonarr.tv/donate)
++Upstream Sonarr's anime search always falls through to per-episode queries — one HTTP request per episode — creating unnecessary load on genre-oriented indexers. This fork inserts intelligent early-exit checks into the search cascade:
+ 
+-## Support
++1. **Pack search** — if an approved release covers all wanted episodes across seasons, stop immediately
++2. **Season search** — per season, if an approved release covers all wanted episodes, skip its episodes
++3. **Per-episode search** — only for episodes not covered by steps 1-2
+ 
+-Note: GitHub Issues are for Bugs and Feature Requests Only
++Additional capabilities:
++- **Multi-season pack support** — recognizes `S01-S04` range and `S01+S02+S03+S04` list formats, uses them to skip later-season queries
++- **Bare-title pack matching** — during anime season search, releases like `[Group] Example Anime Title [1080p]` can be matched as Season 1 even when they include no episode numbers, no `S01`, and no `Season 1`, as long as they are just the series title plus safe trailing metadata
++- **Anime specials/OVAs** — Season 0 searches use OVA/Special-aware query generation instead of the pack fallback
++- **Bare-title + OVA matching** — releases with inline alternate-title parentheses and trailing metadata are correctly recognized during Season 0 special search
++- **S01+Specials co-coverage** — when a season pack explicitly advertises special content (e.g. `S01+Specials`, `S01+OVA`), the pack maps both the season episodes and exactly one wanted Season 0 special, allowing the S00 search to be skipped entirely
++- **Pack-first parity across supported backends** — protocol-backed search backends emit a broad title-only query before season-specific queries, matching the native pack-first behavior. Cross-season dedup prevents the same broad query from being sent twice
++- **Grab history fallback for unparseable titles** — when a download completes with a title that cannot be parsed (common for some anime packs), the fork falls back to the original grab history to identify the series and episodes. This prevents automatic imports from being blocked for releases already validated and approved during the search phase.
+ 
+-- [Forums](https://forums.sonarr.tv/)
+-- [Discord](https://discord.gg/M6BvZn5)
+-- [GitHub - Bugs and Feature Requests Only](https://github.com/Sonarr/Sonarr/issues)
+-- [IRC](https://web.libera.chat/?channels=#sonarr)
+-- [Reddit](https://www.reddit.com/r/sonarr)
+-- [Wiki](https://wiki.servarr.com/sonarr)
++## What this fork does not do
+ 
+-## Features
++- **Not a full product divergence.** The UI, library management, indexer configuration, download clients, quality profiles, and all non-anime search behavior are identical to upstream Sonarr v4.
++- **Not a replacement for upstream support.** Bugs or questions about general Sonarr behavior (import, notifications, database, API) should go to [upstream Sonarr](https://github.com/Sonarr/Sonarr).
++- **Some backend variants remain lightly tested.** Validation so far has focused on accessible indexers and standard protocol-backed backends. Non-standard implementations may behave differently.
+ 
+-### Current Features
++## Example behavior
+ 
+-- Support for major platforms: Windows, Linux, macOS, Raspberry Pi, etc.
+-- Automatically detects new episodes
+-- Can scan your existing library and download any missing episodes
+-- Can watch for better quality of the episodes you already have and do an automatic upgrade. _eg. from DVD to Blu-Ray_
+-- Automatic failed download handling will try another release if one fails
+-- Manual search so you can pick any release or to see why a release was not downloaded automatically
+-- Fully configurable episode renaming
+-- Full integration with SABnzbd and NZBGet
+-- Full integration with Kodi, Plex (notification, library update, metadata)
+-- Full support for specials and multi-episode releases
+-- And a beautiful UI
++Illustrative example only:
+ 
+-## Contributing
++| Series | Seasons | Episodes | Queries (fork example) | Queries (upstream-style example) | Per-episode fallbacks |
++|--------|---------|----------|------------------------|----------------------------------|-----------------------|
++| Anime Title | S01-S04 | 96 | 2 | ~104 | 0 |
++| Anime Title: Season 1 | S01 | 12 | 6 | ~15 | 0 |
++| Anime Title: Long Season | S01 | 26 | 3 | ~29 | 0 |
+ 
+-### Development
++The goal is simple: if a broad pack or season pack already covers the wanted episodes, the fork avoids sending unnecessary per-episode searches afterward. Actual results depend on indexer behavior and available releases.
+ 
+-This project exists thanks to all the people who contribute. [Contribute](CONTRIBUTING.md).
++## Tested paths
+ 
+-<a href="https://github.com/Sonarr/Sonarr/graphs/contributors"><img src="https://opencollective.com/Sonarr/contributors.svg?width=890&button=false" /></a>
++| Test path | Command | What it validates |
++|-----------|---------|-------------------|
++| Direct indexer path | `/test-e2e [series] [seasons]` | Pack-first cascade, broad query suppression, episode skip logic |
++| Aggregator-backed path | `/test-e2e-prowlarr [series] [seasons]` | Same cascade behavior through a protocol-backed path |
++| CI unit tests | Automatic on push/PR | Core test suite across Windows, macOS, and Linux |
++| CI unit tests (Postgres) | Automatic on push/PR | Core test suite on Ubuntu with Postgres environment enabled |
++| CI integration tests | Automatic on push/PR | Full integration test matrix across Windows, macOS, and Linux |
+ 
+-### Supporters
++**Note on query counts:** Native indexer implementations can be leaner than protocol-backed paths, which may also emit identifier-based and title-variant queries. The acceptance criteria are broad-first ordering, cross-season suppression, and cascade/skip behavior, not identical query totals across every backend.
+ 
+-This project would not be possible without the support of our users and software providers.
+-[**Become a sponsor or backer**](https://opencollective.com/sonarr) to help us out!
++## Known limitations
+ 
+-#### Mega Sponsors
++- Fork tracks Sonarr v4 (current stable) only; v5/develop is not targeted
++- Pack detection depends on release title parsing — unusual naming conventions may not be recognized
++- Protocol-backed indexers with non-standard search parameter support may not benefit from broad-first ordering
++- Multi-season coverage still depends on what a given indexer exposes for the searched title
+ 
+-[![Sponsors](https://opencollective.com/sonarr/tiers/mega-sponsor.svg?width=890)](https://opencollective.com/sonarr/contribute/mega-sponsor-21443/checkout)
++## Install
+ 
+-#### Sponsors
++### GitHub release archives
+ 
+-[![Flexible Sponsors](https://opencollective.com/sonarr/sponsors.svg?width=890)](https://opencollective.com/sonarr/contribute/sponsor-21457/checkout)
++Download the latest release from the [Releases page](https://github.com/RemingtonDev/sonarr-anime/releases/latest). Releases are published with version tags such as `v4.0.17.812`. Archives are available for Linux (x64, arm, arm64), macOS (x64, arm64), Windows (x64, x86), and FreeBSD.
+ 
+-#### Backers
++Extract and run like stock Sonarr — the binary is a drop-in replacement.
+ 
+-[![Backers](https://opencollective.com/sonarr/backers.svg?width=890)](https://opencollective.com/sonarr/contribute/backer-21442/checkout)
++### Docker
+ 
+-#### JetBrains
++Public images are available on GitHub Container Registry (GHCR):
+ 
+-Thank you to [<img src="https://resources.jetbrains.com/storage/products/company/brand/logos/jetbrains.png" alt="JetBrains" width="96">](http://www.jetbrains.com/) for providing us with free licenses to their great tools
++```
++ghcr.io/remingtondev/sonarr-anime
++```
+ 
+-[<img src="https://resources.jetbrains.com/storage/products/company/brand/logos/TeamCity.png" alt="TeamCity" width="64">](http://www.jetbrains.com/teamcity/)
++Supported architectures: `linux/amd64` and `linux/arm64`.
+ 
+-[<img src="https://resources.jetbrains.com/storage/products/company/brand/logos/ReSharper.png" alt="ReSharper" width="64">](http://www.jetbrains.com/resharper/)
++### Docker quick start
+ 
+-[<img src="https://resources.jetbrains.com/storage/products/company/brand/logos/dotTrace.png" alt="dotTrace" width="64">](http://www.jetbrains.com/dottrace/)
++**docker run:**
+ 
+-[<img src="https://resources.jetbrains.com/storage/products/company/brand/logos/Rider.png" alt="Rider" width="64">](http://www.jetbrains.com/rider/)
++```bash
++docker run -d \
++  --name sonarr-anime \
++  -p 8989:8989 \
++  -v /path/to/config:/config \
++  -v /path/to/tv:/tv \
++  -v /path/to/downloads:/downloads \
++  ghcr.io/remingtondev/sonarr-anime:latest
++```
+ 
+-### Licenses
++**docker compose:**
+ 
+-- [GNU GPL v3](http://www.gnu.org/licenses/gpl.html)
+-- Copyright 2010-2024
++```yaml
++services:
++  sonarr:
++    image: ghcr.io/remingtondev/sonarr-anime:latest
++    container_name: sonarr-anime
++    ports:
++      - "8989:8989"
++    volumes:
++      - ./config:/config
++      - /path/to/tv:/tv
++      - /path/to/downloads:/downloads
++    restart: unless-stopped
++```
++
++### NAS / self-hosted container platforms
++
++The public images support `amd64` and `arm64`, covering Synology, QNAP, Unraid, and similar NAS platforms.
++
++Required mounts:
++
++| Mount | Purpose |
++|-------|---------|
++| `/config` | Sonarr configuration, database, and logs. Persists across container restarts. |
++| `/tv` | TV library root folder. Must match what you configure inside Sonarr. |
++| `/downloads` | Download client output. Must be accessible to both Sonarr and your download client. |
++
++For conservative installs, pin to an exact release tag such as `4.0.17.812`. Use `latest` only if you want the current stable build.
++
++**Upgrading:**
++
++1. Stop the container
++2. Pull the new image (`docker pull ghcr.io/remingtondev/sonarr-anime:latest`)
++3. Restart with the same mounted `/config`
++
++Your configuration and database are preserved in the `/config` volume.
++
++## Versioning
++
++Releases use Sonarr's normal numeric build versioning.
++The About page also shows this fork's `releaseVersion`, which is the fork-specific release identifier surfaced alongside the normal upstream-style app versioning.
++
++Example:
++
++- GitHub release tag: `v4.0.17.812`
++- Docker image tag: `4.0.17.812`
++
++Successful `main` builds publish:
++
++- a GitHub Release tagged `v<version>`
++- packaged release archives
++- a GHCR image tagged `<version>`
++- `latest` after the matching GitHub Release has been created successfully
++
++## Image tags
++
++| Tag | Source | Description |
++|-----|--------|-------------|
++| `latest` | `main` | Alias for the most recent successful GitHub Release |
++| `4.0.17.812` | `main` | Pinned image tag for a specific published release |
++
++Stable releases come from `main`.
++
++## Security
++
++This is an independent fork, not the official Sonarr distribution. It is not affiliated with or endorsed by the Sonarr project.
++
++See [SECURITY.md](SECURITY.md) for how to report vulnerabilities in fork-owned code and release infrastructure.
++
++## Support expectations
++
++Issues are welcome for:
++- Reproducible anime-search regressions (pack cascade, query counts, parser failures)
++- Indexer compatibility reports for genre-oriented indexers and protocol-backed backends
++- Fork-owned workflow, docs, or release problems
++
++For general Sonarr support (UI, import, notifications, download clients, database), please use the [upstream Sonarr community](https://wiki.servarr.com/sonarr). This fork does not change those features.
++
++## Upstream sync
++
++This fork tracks Sonarr v4 and is rebased onto upstream manually when needed. There is no automatic sync PR flow; upstream changes are reviewed and merged deliberately to keep the fork surface small.
++
++## For developers
++
++- [Contributing guide](CONTRIBUTING.md) — how to contribute to this fork
++
++## License
++
++Same as upstream Sonarr — [GNU GPL v3](http://www.gnu.org/licenses/gpl.html).
+diff --git a/SECURITY.md b/SECURITY.md
+index a534ff2fb09dc18c294502bee17a7d9223d6fed4..6b1ae358f5bffcc01b7d8a37e14fb91d03b036e9 100644
+--- a/SECURITY.md
++++ b/SECURITY.md
+@@ -2,8 +2,17 @@
+ 
+ ## Reporting a Vulnerability
+ 
+-Please report (suspected) security vulnerabilities on Discord (preferred) to
+-either markus101
+-#2148 or Taloth#7357 or via email: security@sonarr.tv. You will receive a response from
+-us within 72 hours. If the issue is confirmed, we will release a patch as soon
+-as possible depending on complexity/severity.
++Please report suspected security vulnerabilities through [GitHub private vulnerability reporting](https://github.com/RemingtonDev/sonarr-anime/security/advisories/new). Do not file security issues as public GitHub issues.
++
++This fork publishes its own release archives and container images. This policy covers vulnerabilities in fork-owned code and release infrastructure. For vulnerabilities in upstream Sonarr unrelated to this fork's changes, please report them to the [Sonarr project](https://github.com/Sonarr/Sonarr).
++
++## What to Report
++
++- Vulnerabilities in fork-owned search optimization changes
++- Secrets or credentials exposed in release or CI infrastructure
++- Docker images or release artifacts that include unintended files
++
++## What Not to Report Here
++
++- General Sonarr vulnerabilities unrelated to this fork's patches — report those to upstream Sonarr
++- Feature requests or bug reports — use the [issue templates](https://github.com/RemingtonDev/sonarr-anime/issues/new/choose)
+diff --git a/build.sh b/build.sh
+index ee59d2f6176573c2faaea58ba3acd06f0e8f3dc8..92d2317f89b6307e9b68a032e01b0dd599d5676f 100755
+--- a/build.sh
++++ b/build.sh
+@@ -20,11 +20,13 @@ ProgressEnd()
+ 
+ UpdateVersionNumber()
+ {
+-    if [ "$SONARR_VERSION" != "" ]; then
+-        echo "Updating version info to: $SONARR_VERSION"
+-        sed -i'' -e "s/<AssemblyVersion>[0-9.*]\+<\/AssemblyVersion>/<AssemblyVersion>$SONARR_VERSION<\/AssemblyVersion>/g" src/Directory.Build.props
++    local appVersion="${APP_VERSION:-$SONARR_VERSION}"
++
++    if [ "$appVersion" != "" ]; then
++        echo "Updating version info to: $appVersion"
++        sed -i'' -e "s/<AssemblyVersion>[0-9.*]\+<\/AssemblyVersion>/<AssemblyVersion>$appVersion<\/AssemblyVersion>/g" src/Directory.Build.props
+         sed -i'' -e "s/<AssemblyConfiguration>[\$()A-Za-z-]\+<\/AssemblyConfiguration>/<AssemblyConfiguration>${BRANCH}<\/AssemblyConfiguration>/g" src/Directory.Build.props
+-        sed -i'' -e "s/<string>10.0.0.0<\/string>/<string>$SONARR_VERSION<\/string>/g" distribution/macOS/Sonarr.app/Contents/Info.plist
++        sed -i'' -e "s/<string>10.0.0.0<\/string>/<string>$appVersion<\/string>/g" distribution/macOS/Sonarr.app/Contents/Info.plist
+     fi
+ }
+ 
+@@ -275,6 +277,7 @@ UploadTestArtifacts()
+ UploadArtifacts()
+ {
+     local framework="$1"
++    local artifactVersion="${RELEASE_VERSION:-${APP_VERSION:-$SONARR_VERSION}}"
+ 
+     ProgressStart 'Publishing Artifacts'
+ 
+@@ -283,7 +286,7 @@ UploadArtifacts()
+     do
+         local runtime=$(basename "$dir")
+ 
+-        echo "##teamcity[publishArtifacts '$artifactsFolder/$runtime/$framework/** => Sonarr.$BRANCH.$SONARR_VERSION.$runtime.zip']"
++        echo "##teamcity[publishArtifacts '$artifactsFolder/$runtime/$framework/** => Sonarr.$BRANCH.$artifactVersion.$runtime.zip']"
+     done
+ 
+     # Debian Package / Windows installer / macOS app
+diff --git a/distribution/windows/setup/build.bat b/distribution/windows/setup/build.bat
+index 6c205089ee5721d50867fccb495b82e014ce3084..0864fe66f147ea3deced263de3c1e2e7572c17cb 100644
+--- a/distribution/windows/setup/build.bat
++++ b/distribution/windows/setup/build.bat
+@@ -1,5 +1,6 @@
+ @REM SET SONARR_MAJOR_VERSION=4
+-@REM SET SONARR_VERSION=4.0.0.5
++@REM SET APP_VERSION=4.0.17.2952
++@REM SET RELEASE_VERSION=4.0.17.2952-anime.1
+ @REM SET BRANCH=develop
+ @REM SET FRAMEWORK=net6.0
+ @REM SET RUNTIME=win-x64
+diff --git a/distribution/windows/setup/sonarr.iss b/distribution/windows/setup/sonarr.iss
+index 8401bdea9033b5f29deffaec4fc37f50dc643b1e..e2457af8085f5349cb9c7a3a52ea5832e54036de 100644
+--- a/distribution/windows/setup/sonarr.iss
++++ b/distribution/windows/setup/sonarr.iss
+@@ -6,8 +6,10 @@
+ #define AppURL "https://sonarr.tv/"
+ #define ForumsURL "https://forums.sonarr.tv/"
+ #define AppExeName "Sonarr.exe"
+-#define BuildNumber "4.0"
+-#define BuildNumber GetEnv('SONARR_VERSION')
++#define BuildNumber "4.0.17.2952-anime.1"
++#define BuildNumber GetEnv('RELEASE_VERSION')
++#define AppBuildVersion "4.0.17.2952"
++#define AppBuildVersion GetEnv('APP_VERSION')
+ #define MajorVersion GetEnv('SONARR_MAJOR_VERSION')
+ #define BranchName GetEnv('BRANCH')
+ #define Framework GetEnv('FRAMEWORK')
+@@ -19,7 +21,7 @@
+ ; (To generate a new GUID, click Tools | Generate GUID inside the IDE.)
+ AppId={{56C1065D-3523-4025-B76D-6F73F67F7F71}
+ AppName={#AppName}
+-AppVersion={#MajorVersion}
++AppVersion={#AppBuildVersion}
+ AppPublisher={#AppPublisher}
+ AppPublisherURL={#AppURL}
+ AppSupportURL={#ForumsURL}
+@@ -38,7 +40,7 @@ DisableReadyPage=True
+ CompressionThreads=2
+ Compression=lzma2/normal
+ AppContact={#ForumsURL}
+-VersionInfoVersion={#MajorVersion}
++VersionInfoVersion={#AppBuildVersion}
+ SetupLogging=yes
+ OutputDir="..\..\..\_artifacts"
+ AppverName={#AppName}
+diff --git a/docker/tests/mono/sonarr/Dockerfile b/docker/tests/mono/sonarr/Dockerfile
+deleted file mode 100644
+index f2ec42a9e1af09822f46a1f3f46e6df2d2c9e888..0000000000000000000000000000000000000000
+--- a/docker/tests/mono/sonarr/Dockerfile
++++ /dev/null
+@@ -1,32 +0,0 @@
+-FROM ubuntu:xenial
+-
+-ENV DEBIAN_FRONTEND noninteractive
+-ARG MONO_VERSION=5.20
+-ARG MONO_URL=stable-xenial/snapshots/$MONO_VERSION
+-
+-RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+-    echo "deb http://download.mono-project.com/repo/debian $MONO_URL main" > /etc/apt/sources.list.d/mono-official-stable.list && \
+-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 2009837CBFFD68F45BC180471F4F90DE2A9B4BF8 && \
+-    echo "deb http://apt.sonarr.tv/ubuntu xenial main" > /etc/apt/sources.list.d/sonarr.list && \
+-    apt-get update && apt-get install -y \ 
+-        tofrodos tzdata \
+-        sonarr \
+-        sqlite3 mediainfo \
+-        && rm -rf /var/lib/apt/lists/*
+-
+-RUN apt-get update && apt-get install -y \ 
+-        libmono-system-runtime4.0-cil \
+-        libmono-system-net-http4.0-cil \
+-        && rm -rf /var/lib/apt/lists/*
+-
+-COPY startup.sh /startup.sh
+-RUN  fromdos /startup.sh
+-
+-WORKDIR /data/
+-VOLUME ["/data/_tests_linux", "/data/_output_linux", "/data/_tests_results"]
+-
+-RUN groupadd sonarrtst -g 4020 && useradd sonarrtst -u 4021 -g 4020 -m -s /bin/bash
+-USER sonarrtst
+-
+-CMD bash /startup.sh
+-
+diff --git a/frontend/src/App/AppUpdatedModalContent.tsx b/frontend/src/App/AppUpdatedModalContent.tsx
+index 6553d6270c32552b169db36ab6151e4e157b5aaf..e2a9ae0d943c21db8e188e87449a3e0d4a86954c 100644
+--- a/frontend/src/App/AppUpdatedModalContent.tsx
++++ b/frontend/src/App/AppUpdatedModalContent.tsx
+@@ -1,5 +1,6 @@
+ import React, { useCallback, useEffect } from 'react';
+ import { useDispatch, useSelector } from 'react-redux';
++import Alert from 'Components/Alert';
+ import Button from 'Components/Link/Button';
+ import LoadingIndicator from 'Components/Loading/LoadingIndicator';
+ import InlineMarkdown from 'Components/Markdown/InlineMarkdown';
+@@ -100,6 +101,12 @@ function AppUpdatedModalContent(props: AppUpdatedModalContentProps) {
+           />
+         </div>
+ 
++        <Alert kind="info">
++          This build includes anime-specific changes from the sonarr-anime fork.
++          The release notes below come from upstream Sonarr and may not list
++          fork-only behavior.
++        </Alert>
++
+         {isPopulated && !error && !!update ? (
+           <div>
+             {update.changes ? (
+diff --git a/frontend/src/Components/Markdown/InlineMarkdown.tsx b/frontend/src/Components/Markdown/InlineMarkdown.tsx
+index 80e99336a17c15c9423a3872885b8401de3f91c7..d67aff11b2bb48d784ded85cff6ce5f19fa7df8b 100644
+--- a/frontend/src/Components/Markdown/InlineMarkdown.tsx
++++ b/frontend/src/Components/Markdown/InlineMarkdown.tsx
+@@ -9,59 +9,40 @@ interface InlineMarkdownProps {
+ 
+ function InlineMarkdown(props: InlineMarkdownProps) {
+   const { className, data, blockClassName } = props;
+-
+-  // For now only replace links or code blocks (not both)
+   const markdownBlocks: (ReactElement | string)[] = [];
+ 
+   if (data) {
+-    const linkRegex = RegExp(/\[(.+?)\]\((.+?)\)/g);
++    const markdownRegex = /\[([^\]]+?)\]\(([^)]+?)\)|`([^`]+?)`/g;
+ 
+     let endIndex = 0;
+-    let match = null;
++    let match: RegExpExecArray | null = null;
+ 
+-    while ((match = linkRegex.exec(data)) !== null) {
++    while ((match = markdownRegex.exec(data)) !== null) {
+       if (match.index > endIndex) {
+-        markdownBlocks.push(data.substr(endIndex, match.index - endIndex));
++        markdownBlocks.push(data.slice(endIndex, match.index));
+       }
+ 
+-      markdownBlocks.push(
+-        <Link key={match.index} to={match[2]}>
+-          {match[1]}
+-        </Link>
+-      );
+-      endIndex = match.index + match[0].length;
+-    }
+-
+-    if (endIndex !== data.length && markdownBlocks.length > 0) {
+-      markdownBlocks.push(data.substr(endIndex, data.length - endIndex));
+-    }
+-
+-    const codeRegex = RegExp(/(?=`)`(?!`)[^`]*(?=`)`(?!`)/g);
+-
+-    endIndex = 0;
+-    match = null;
+-    let matchedCode = false;
+-
+-    while ((match = codeRegex.exec(data)) !== null) {
+-      matchedCode = true;
+-
+-      if (match.index > endIndex) {
+-        markdownBlocks.push(data.substr(endIndex, match.index - endIndex));
++      if (match[1] && match[2]) {
++        markdownBlocks.push(
++          <Link key={`link-${match.index}`} to={match[2]}>
++            {match[1]}
++          </Link>
++        );
++      } else if (match[3]) {
++        markdownBlocks.push(
++          <code
++            key={`code-${match.index}`}
++            className={blockClassName ?? undefined}
++          >
++            {match[3]}
++          </code>
++        );
+       }
+-
+-      markdownBlocks.push(
+-        <code
+-          key={`code-${match.index}`}
+-          className={blockClassName ?? undefined}
+-        >
+-          {match[0].substring(1, match[0].length - 1)}
+-        </code>
+-      );
+       endIndex = match.index + match[0].length;
+     }
+ 
+-    if (endIndex !== data.length && markdownBlocks.length > 0 && matchedCode) {
+-      markdownBlocks.push(data.substr(endIndex, data.length - endIndex));
++    if (markdownBlocks.length > 0 && endIndex < data.length) {
++      markdownBlocks.push(data.slice(endIndex));
+     }
+ 
+     if (markdownBlocks.length === 0) {
+diff --git a/frontend/src/System/Status/About/About.tsx b/frontend/src/System/Status/About/About.tsx
+index a7ca645365c93a1f616b14a2809a8ef90b3a53da..9c522d21c0fc8598a7fa9dec31591c0bc513121c 100644
+--- a/frontend/src/System/Status/About/About.tsx
++++ b/frontend/src/System/Status/About/About.tsx
+@@ -17,6 +17,7 @@ function About() {
+ 
+   const {
+     version,
++    releaseVersion,
+     packageVersion,
+     packageAuthor,
+     isNetCore,
+@@ -31,6 +32,8 @@ function About() {
+     startTime,
+   } = item;
+ 
++  const displayedVersion = releaseVersion || version;
++
+   useEffect(() => {
+     dispatch(fetchStatus());
+   }, [dispatch]);
+@@ -38,7 +41,19 @@ function About() {
+   return (
+     <FieldSet legend={translate('About')}>
+       <DescriptionList className={styles.descriptionList}>
+-        <DescriptionListItem title={translate('Version')} data={version} />
++        <DescriptionListItem
++          title="Fork"
++          data={
++            <InlineMarkdown
++              data={`sonarr-anime running, build \`${displayedVersion}\` · [RemingtonDev/sonarr-anime](https://github.com/RemingtonDev/sonarr-anime)`}
++            />
++          }
++        />
++
++        <DescriptionListItem
++          title={translate('Version')}
++          data={displayedVersion}
++        />
+ 
+         {packageVersion && (
+           <DescriptionListItem
+diff --git a/frontend/src/typings/SystemStatus.ts b/frontend/src/typings/SystemStatus.ts
+index d5eab3ca34ffd0d9c32945732ca505a5c02c05e5..e8b06e384de25cfbc05cb8c9f43e6efc66554b0d 100644
+--- a/frontend/src/typings/SystemStatus.ts
++++ b/frontend/src/typings/SystemStatus.ts
+@@ -24,6 +24,7 @@ interface SystemStatus {
+   packageUpdateMechanism: string;
+   packageUpdateMechanismMessage: string;
+   packageVersion: string;
++  releaseVersion: string;
+   runtimeName: string;
+   runtimeVersion: string;
+   sqliteVersion: string;
+diff --git a/global.json b/global.json
+index 5f5ece165083bf4d740b63836fbe0e2e42006f2f..10b65be86420429d3f1486032aa1be656250d5a3 100644
+--- a/global.json
++++ b/global.json
+@@ -1,5 +1,6 @@
+ {
+   "sdk": {
+-    "version": "6.0.405"
++    "version": "6.0.100",
++    "rollForward": "latestFeature"
+   }
+ }
+diff --git a/local-test/docker-compose.yml b/local-test/docker-compose.yml
+new file mode 100644
+index 0000000000000000000000000000000000000000..59ae2ac6c7662e1715c299ce8ac09faf41d84b60
+--- /dev/null
++++ b/local-test/docker-compose.yml
+@@ -0,0 +1,21 @@
++services:
++  sonarr:
++    image: sonarr-anime:local
++    container_name: sonarr-anime-local
++    platform: linux/amd64
++    ports:
++      - "8989:8989"
++    volumes:
++      - ./config:/config
++      - ./tv:/tv
++    restart: unless-stopped
++
++  prowlarr:
++    image: lscr.io/linuxserver/prowlarr@sha256:9ef5d8bf832edcacb6082f9262cb36087854e78eb7b1c3e1d4375056055b2d82  # 2.3.0.5236-ls139
++    container_name: prowlarr-local
++    platform: linux/amd64
++    ports:
++      - "9696:9696"
++    volumes:
++      - ./prowlarr-config:/config
++    restart: unless-stopped
+diff --git a/src/Directory.Build.props b/src/Directory.Build.props
+index 239a98d737d9a9935b20db9f72bb99b26b6f10d7..90d0d970beb271fd8aa27955112b0debe2c4ed8b 100644
+--- a/src/Directory.Build.props
++++ b/src/Directory.Build.props
+@@ -129,14 +129,21 @@
+ 
+   <!-- Standard testing packages -->
+   <ItemGroup Condition="'$(TestProject)'=='true'">
+-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
++    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+     <PackageReference Include="NUnit" Version="3.13.3" />
+-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+-    <PackageReference Include="NunitXml.TestLogger" Version="3.0.131" />
++    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
++    <PackageReference Include="NunitXml.TestLogger" Version="4.0.254" />
+   </ItemGroup>
+ 
+   <ItemGroup Condition="'$(TestProject)'=='true' and '$(TargetFramework)'=='net6.0'">
+-    <PackageReference Include="coverlet.collector" Version="3.0.4-preview.27.ge7cb7c3b40" />
++    <PackageReference Include="coverlet.collector" Version="6.0.2" />
++  </ItemGroup>
++
++  <ItemGroup Condition="'$(TestProject)'=='true' and '$(IsOSX)'=='true'">
++    <None Include="$(NuGetPackageRoot)system.data.sqlite.core.servarr\1.0.115.5-18\runtimes\osx-$(Architecture)\native\netstandard2.0\libsqlite3.dylib">
++      <Link>libsqlite3.dylib</Link>
++      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
++    </None>
+   </ItemGroup>
+ 
+   <PropertyGroup Condition="'$(SonarrProject)'=='true' and '$(EnableAnalyzers)'=='false'">
+diff --git a/src/Sonarr.Api.V3/System/SystemController.cs b/src/Sonarr.Api.V3/System/SystemController.cs
+index 80d177cfb5eb0c949ae2d343dad3668af228fcfd..122e2c96abc94b18fa21a729aa5255d25cc7961f 100644
+--- a/src/Sonarr.Api.V3/System/SystemController.cs
++++ b/src/Sonarr.Api.V3/System/SystemController.cs
+@@ -89,7 +89,8 @@ public SystemResource GetStatus()
+                 PackageVersion = _deploymentInfoProvider.PackageVersion,
+                 PackageAuthor = _deploymentInfoProvider.PackageAuthor,
+                 PackageUpdateMechanism = _deploymentInfoProvider.PackageUpdateMechanism,
+-                PackageUpdateMechanismMessage = _deploymentInfoProvider.PackageUpdateMechanismMessage
++                PackageUpdateMechanismMessage = _deploymentInfoProvider.PackageUpdateMechanismMessage,
++                ReleaseVersion = _deploymentInfoProvider.ReleaseVersion
+             };
+         }
+ 
+diff --git a/src/Sonarr.Api.V3/System/SystemResource.cs b/src/Sonarr.Api.V3/System/SystemResource.cs
+index 53f35921eb543dcc76b67e45962afb86ce6c3b0f..a89cfc703a6a8df6de6167b25812fff82f9753fd 100644
+--- a/src/Sonarr.Api.V3/System/SystemResource.cs
++++ b/src/Sonarr.Api.V3/System/SystemResource.cs
+@@ -38,6 +38,7 @@ public class SystemResource
+         public string PackageAuthor { get; set; }
+         public UpdateMechanism PackageUpdateMechanism { get; set; }
+         public string PackageUpdateMechanismMessage { get; set; }
++        public string ReleaseVersion { get; set; }
+         public Version DatabaseVersion { get; set; }
+         public DatabaseType DatabaseType { get; set; }
+     }
+diff --git a/src/Sonarr.Api.V3/openapi.json b/src/Sonarr.Api.V3/openapi.json
+index 6ac128ffd5bd37278762eb0c46287b4516356c57..015c9d2f2ab69abf9c9a10064ab10aed3be4f89a 100644
+--- a/src/Sonarr.Api.V3/openapi.json
++++ b/src/Sonarr.Api.V3/openapi.json
+@@ -12134,6 +12134,10 @@
+             "type": "string",
+             "nullable": true
+           },
++          "releaseVersion": {
++            "type": "string",
++            "nullable": true
++          },
+           "databaseVersion": {
+             "type": "string",
+             "nullable": true
+@@ -12480,4 +12484,4 @@
+       "apikey": [ ]
+     }
+   ]
+-}
+\ No newline at end of file
++}

--- a/.fork/patches/0002-anime-core.patch
+++ b/.fork/patches/0002-anime-core.patch
@@ -1,0 +1,1549 @@
+diff --git a/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs b/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs
+index 992f2a26fc6859214dd29fa20f677aa22ce8cd86..c6350f20e272aae29fbbed0239a064638af85f4b 100644
+--- a/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs
++++ b/src/NzbDrone.Core/Datastore/Migration/Framework/MigrationController.cs
+@@ -8,7 +8,6 @@
+ using Microsoft.Extensions.DependencyInjection;
+ using Microsoft.Extensions.Logging;
+ using NLog;
+-using NLog.Extensions.Logging;
+ 
+ namespace NzbDrone.Core.Datastore.Migration.Framework
+ {
+@@ -35,12 +34,14 @@ public void Migrate(string connectionString, MigrationContext migrationContext,
+ 
+             _logger.Info("*** Migrating {0} ***", connectionString);
+ 
+-            ServiceProvider serviceProvider;
+-
+             var db = databaseType == DatabaseType.SQLite ? "sqlite" : "postgres";
+ 
+-            serviceProvider = new ServiceCollection()
+-                .AddLogging(b => b.AddNLog())
++            using var serviceProvider = new ServiceCollection()
++                .AddLogging(b =>
++                {
++                    b.ClearProviders();
++                    b.AddProvider(_migrationLoggerProvider);
++                })
+                 .AddFluentMigratorCore()
+                 .Configure<RunnerOptions>(cfg => cfg.IncludeUntaggedMaintenances = true)
+                 .ConfigureRunner(
+diff --git a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+old mode 100644
+new mode 100755
+index aac270bcf99b91d99d00dbb18659fb1cbc9eae70..2f8588d6fd3190ed8d38fe63b63f4508d1edfe70
+--- a/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
++++ b/src/NzbDrone.Core/DecisionEngine/DownloadDecisionMaker.cs
+@@ -1,6 +1,7 @@
+ using System;
+ using System.Collections.Generic;
+ using System.Linq;
++using System.Text.RegularExpressions;
+ using NLog;
+ using NzbDrone.Common.Extensions;
+ using NzbDrone.Common.Instrumentation.Extensions;
+@@ -12,6 +13,7 @@
+ using NzbDrone.Core.IndexerSearch.Definitions;
+ using NzbDrone.Core.Parser;
+ using NzbDrone.Core.Parser.Model;
++using NzbDrone.Core.Tv;
+ 
+ namespace NzbDrone.Core.DecisionEngine
+ {
+@@ -23,6 +25,39 @@ public interface IMakeDownloadDecision
+ 
+     public class DownloadDecisionMaker : IMakeDownloadDecision
+     {
++        private const string SafeToken =
++            @"(?:" +
++            @"Multi[\s-]?Dual[\s-]?Audio|Dual[\s-]?Audio|Multi[\s-]?Audio|Multi[\s-]?Subs?|Eng(?:lish)?[\s-]?Subs?" +
++            @"|10[\s-]?bit|Hi10[Pp]?" +
++            @"|Blu[\s-]?Ray|WEB[\s-]?(?:DL|Rip)|DVD[\s-]?Rip|BD[\s-]?Rip" +
++            @"|[0-9]{3,4}[piPI]|4[Kk]" +
++            @"|DVD|BD|WEB|HDTV" +
++            @"|[xX]\.?26[45]|HEVC|AVC|AV1|VP9" +
++            @"|AAC|OPUS|FLAC|AC3|DTS|MP3|TrueHD|Atmos" +
++            @"|MKV|MP4|AVI" +
++            @"|Batch|Complete" +
++            @")";
++
++        private static readonly Regex LeadingSubgroupRegex = new Regex(@"^\[.+?\][-_. ]*", RegexOptions.Compiled);
++        private static readonly Regex TrailingBracketsRegex = new Regex(@"(?:\s*[\[\(][^\[\]()]*[\]\)])+\s*$", RegexOptions.Compiled);
++        private static readonly Regex SpecialContentRegex = new Regex(@"\b(Movie|OVA|OVD|Special|Extras|NCED|NCOP|Bonus)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
++        private static readonly Regex SingleBlockRegex = new Regex(@"[\[\(]\s*([^\[\]()]+?)\s*[\]\)]", RegexOptions.Compiled);
++        private static readonly Regex SafeBlockContentRegex = new Regex(
++            @"^" + SafeToken + @"(?:[\s-]+" + SafeToken + @")*$",
++            RegexOptions.IgnoreCase | RegexOptions.Compiled);
++        private static readonly Regex YearBlockRegex = new Regex(@"^\d{4}$", RegexOptions.Compiled);
++
++        private static readonly Regex AnimeSpecialKeywordRegex = new Regex(
++            @"\b(OVA|OAV|Special|Specials)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
++        private static readonly Regex NonEpisodeMarkerRegex = new Regex(
++            @"\b(Extras|NCOP|NCED|Menu|Bonus)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
++        private static readonly Regex TrailingSeparatorsRegex = new Regex(
++            @"[\s+\-_]+$", RegexOptions.Compiled);
++        private static readonly Regex TrailingGroupSuffixRegex = new Regex(
++            @"(?<=[\]\)])[-_]\w+$", RegexOptions.Compiled);
++        private static readonly Regex InlineParenBlockRegex = new Regex(
++            @"\([^)]+\)", RegexOptions.Compiled);
++
+         private readonly IEnumerable<IDownloadDecisionEngineSpecification> _specifications;
+         private readonly IParsingService _parsingService;
+         private readonly ICustomFormatCalculationService _formatCalculator;
+@@ -88,6 +123,30 @@ private IEnumerable<DownloadDecision> GetDecisions(List<ReleaseInfo> reports, bo
+                         }
+                     }
+ 
++                    // Anime season search fallback: bare-title packs (no episode markers)
++                    if (searchCriteria is AnimeSeasonSearchCriteria animeSeasonCriteria &&
++                        (parsedEpisodeInfo == null || parsedEpisodeInfo.SeriesTitle.IsNullOrWhiteSpace()))
++                    {
++                        var syntheticInfo = TryBuildAnimeSeasonPackInfo(report, animeSeasonCriteria);
++
++                        if (syntheticInfo != null)
++                        {
++                            parsedEpisodeInfo = syntheticInfo;
++                        }
++                    }
++
++                    // Anime special search fallback: OVA/Special releases for a single requested special
++                    if (searchCriteria is SpecialEpisodeSearchCriteria specialCriteria &&
++                        (parsedEpisodeInfo == null || parsedEpisodeInfo.SeriesTitle.IsNullOrWhiteSpace()))
++                    {
++                        var syntheticInfo = TryBuildAnimeSpecialInfo(report, specialCriteria);
++
++                        if (syntheticInfo != null)
++                        {
++                            parsedEpisodeInfo = syntheticInfo;
++                        }
++                    }
++
+                     if (parsedEpisodeInfo != null && !parsedEpisodeInfo.SeriesTitle.IsNullOrWhiteSpace())
+                     {
+                         var remoteEpisode = _parsingService.Map(parsedEpisodeInfo, report.TvdbId, report.TvRageId, report.ImdbId, searchCriteria);
+@@ -234,5 +293,239 @@ private DownloadRejection EvaluateSpec(IDownloadDecisionEngineSpecification spec
+ 
+             return null;
+         }
++
++        private ParsedEpisodeInfo TryBuildAnimeSeasonPackInfo(ReleaseInfo report, AnimeSeasonSearchCriteria criteria)
++        {
++            // Season 0 is specials — never treat bare-title packs as season 0 packs
++            if (criteria.SeasonNumber == 0)
++            {
++                return null;
++            }
++
++            // Strip leading [SubGroup]
++            var stripped = LeadingSubgroupRegex.Replace(report.Title, "");
++            stripped = stripped.Trim();
++
++            if (stripped.IsNullOrWhiteSpace())
++            {
++                return null;
++            }
++
++            // Require at least one trailing bracket/paren block with safe metadata
++            var blockMatch = TrailingBracketsRegex.Match(stripped);
++            if (!blockMatch.Success)
++            {
++                return null;
++            }
++
++            var titlePart = stripped.Substring(0, blockMatch.Index).Trim();
++            var blocks = SingleBlockRegex.Matches(blockMatch.Value);
++
++            if (blocks.Count == 0)
++            {
++                return null;
++            }
++
++            foreach (Match block in blocks)
++            {
++                var blockValue = block.Groups[1].Value;
++
++                if (!SafeBlockContentRegex.IsMatch(blockValue) && !YearBlockRegex.IsMatch(blockValue))
++                {
++                    return null;
++                }
++            }
++
++            if (titlePart.IsNullOrWhiteSpace())
++            {
++                return null;
++            }
++
++            // Reject titles containing special-content keywords
++            if (SpecialContentRegex.IsMatch(titlePart))
++            {
++                return null;
++            }
++
++            // Verify IDs don't contradict the searched series
++            if (report.TvdbId > 0 && criteria.Series.TvdbId > 0 && report.TvdbId != criteria.Series.TvdbId)
++            {
++                return null;
++            }
++
++            if (report.TvRageId > 0 && criteria.Series.TvRageId > 0 && report.TvRageId != criteria.Series.TvRageId)
++            {
++                return null;
++            }
++
++            if (report.ImdbId.IsNotNullOrWhiteSpace() && criteria.Series.ImdbId.IsNotNullOrWhiteSpace() &&
++                report.ImdbId != criteria.Series.ImdbId)
++            {
++                return null;
++            }
++
++            // Exact cleaned-title match against series title or scene titles
++            var cleanedNormalized = titlePart.CleanSeriesTitle();
++            var seriesClean = criteria.Series.Title.CleanSeriesTitle();
++
++            var matched = cleanedNormalized == seriesClean;
++
++            if (!matched && criteria.SceneTitles != null)
++            {
++                matched = criteria.SceneTitles.Any(st => st.CleanSeriesTitle() == cleanedNormalized);
++            }
++
++            if (!matched)
++            {
++                var withoutParens = InlineParenBlockRegex.Replace(titlePart, "");
++                withoutParens = TrailingSeparatorsRegex.Replace(withoutParens, "");
++                withoutParens = withoutParens.Trim();
++
++                if (!withoutParens.IsNullOrWhiteSpace())
++                {
++                    cleanedNormalized = withoutParens.CleanSeriesTitle();
++                    matched = cleanedNormalized == seriesClean;
++
++                    if (!matched && criteria.SceneTitles != null)
++                    {
++                        matched = criteria.SceneTitles.Any(st => st.CleanSeriesTitle() == cleanedNormalized);
++                    }
++                }
++            }
++
++            if (!matched)
++            {
++                return null;
++            }
++
++            _logger.Debug(
++                "Anime season search fallback: treating '{0}' as season {1} pack for '{2}'",
++                report.Title,
++                criteria.SeasonNumber,
++                criteria.Series.Title);
++
++            return new ParsedEpisodeInfo
++            {
++                ReleaseTitle = report.Title,
++                SeriesTitle = criteria.Series.Title,
++                SeasonNumber = criteria.SeasonNumber,
++                FullSeason = true,
++                EpisodeNumbers = Array.Empty<int>(),
++                AbsoluteEpisodeNumbers = Array.Empty<int>(),
++                Languages = LanguageParser.ParseLanguages(report.Title),
++                Quality = QualityParser.ParseQuality(report.Title)
++            };
++        }
++
++        private ParsedEpisodeInfo TryBuildAnimeSpecialInfo(ReleaseInfo report, SpecialEpisodeSearchCriteria criteria)
++        {
++            // Only for anime series searching for exactly one special episode
++            if (criteria.Series?.SeriesType != SeriesTypes.Anime)
++            {
++                return null;
++            }
++
++            if (criteria.Episodes == null || criteria.Episodes.Count != 1)
++            {
++                return null;
++            }
++
++            var episode = criteria.Episodes[0];
++
++            if (episode.SeasonNumber != 0)
++            {
++                return null;
++            }
++
++            // Must contain OVA/OAV/Special/Specials keyword
++            if (!AnimeSpecialKeywordRegex.IsMatch(report.Title))
++            {
++                return null;
++            }
++
++            // Reject non-episode markers (Extras, NCOP, NCED, Menu, Bonus)
++            if (NonEpisodeMarkerRegex.IsMatch(report.Title))
++            {
++                return null;
++            }
++
++            // Extract series title: strip [SubGroup], trailing group suffix, bracket blocks, and special keywords
++            var stripped = LeadingSubgroupRegex.Replace(report.Title, "").Trim();
++
++            if (stripped.IsNullOrWhiteSpace())
++            {
++                return null;
++            }
++
++            // Strip trailing release-group suffix after final bracket (e.g. "_Rokey", "-Group")
++            stripped = TrailingGroupSuffixRegex.Replace(stripped, "");
++
++            var blockMatch = TrailingBracketsRegex.Match(stripped);
++            var titlePart = blockMatch.Success
++                ? stripped.Substring(0, blockMatch.Index).Trim()
++                : stripped;
++
++            // Remove OVA/Special keywords and clean up separators
++            titlePart = AnimeSpecialKeywordRegex.Replace(titlePart, "");
++            titlePart = TrailingSeparatorsRegex.Replace(titlePart, "");
++            titlePart = titlePart.Trim();
++
++            if (titlePart.IsNullOrWhiteSpace())
++            {
++                return null;
++            }
++
++            // Exact cleaned-title match against series title or scene titles
++            var cleanedNormalized = titlePart.CleanSeriesTitle();
++            var seriesClean = criteria.Series.Title.CleanSeriesTitle();
++
++            var matched = cleanedNormalized == seriesClean;
++
++            if (!matched && criteria.SceneTitles != null)
++            {
++                matched = criteria.SceneTitles.Any(st => st.CleanSeriesTitle() == cleanedNormalized);
++            }
++
++            // Second pass: remove inline parenthesized alt-title blocks and retry
++            if (!matched)
++            {
++                var withoutParens = InlineParenBlockRegex.Replace(titlePart, "");
++                withoutParens = TrailingSeparatorsRegex.Replace(withoutParens, "");
++                withoutParens = withoutParens.Trim();
++
++                if (!withoutParens.IsNullOrWhiteSpace())
++                {
++                    cleanedNormalized = withoutParens.CleanSeriesTitle();
++                    matched = cleanedNormalized == seriesClean;
++
++                    if (!matched && criteria.SceneTitles != null)
++                    {
++                        matched = criteria.SceneTitles.Any(st => st.CleanSeriesTitle() == cleanedNormalized);
++                    }
++                }
++            }
++
++            if (!matched)
++            {
++                return null;
++            }
++
++            _logger.Debug(
++                "Anime special search fallback: treating '{0}' as S00E{1:00} for '{2}'",
++                report.Title,
++                episode.EpisodeNumber,
++                criteria.Series.Title);
++
++            return new ParsedEpisodeInfo
++            {
++                ReleaseTitle = report.Title,
++                SeriesTitle = criteria.Series.Title,
++                SeasonNumber = 0,
++                EpisodeNumbers = new[] { episode.EpisodeNumber },
++                AbsoluteEpisodeNumbers = Array.Empty<int>(),
++                Languages = LanguageParser.ParseLanguages(report.Title),
++                Quality = QualityParser.ParseQuality(report.Title)
++            };
++        }
+     }
+ }
+diff --git a/src/NzbDrone.Core/DecisionEngine/Specifications/MultiSeasonSpecification.cs b/src/NzbDrone.Core/DecisionEngine/Specifications/MultiSeasonSpecification.cs
+index ba117324a97d1df03e95dff5eef381417b200582..17751961d5a5d508ca4a0d48cc9ea43b33025d6c 100644
+--- a/src/NzbDrone.Core/DecisionEngine/Specifications/MultiSeasonSpecification.cs
++++ b/src/NzbDrone.Core/DecisionEngine/Specifications/MultiSeasonSpecification.cs
+@@ -1,6 +1,8 @@
+-﻿using NLog;
++﻿using System.Linq;
++using NLog;
+ using NzbDrone.Core.IndexerSearch.Definitions;
+ using NzbDrone.Core.Parser.Model;
++using NzbDrone.Core.Tv;
+ 
+ namespace NzbDrone.Core.DecisionEngine.Specifications
+ {
+@@ -20,6 +22,21 @@ public virtual DownloadSpecDecision IsSatisfiedBy(RemoteEpisode subject, SearchC
+         {
+             if (subject.ParsedEpisodeInfo.IsMultiSeason)
+             {
++                // Allow anime multi-season packs during anime season search, but only if the pack covers the searched season
++                if (subject.Series.SeriesType == SeriesTypes.Anime &&
++                    searchCriteria is AnimeSeasonSearchCriteria animeSeasonCriteria)
++                {
++                    if (subject.ParsedEpisodeInfo.SeasonNumbers.Length > 0 &&
++                        !subject.ParsedEpisodeInfo.SeasonNumbers.Contains(animeSeasonCriteria.SeasonNumber))
++                    {
++                        _logger.Debug("Anime multi-season pack does not cover searched season {0}, skipping.", animeSeasonCriteria.SeasonNumber);
++                        return DownloadSpecDecision.Reject(DownloadRejectionReason.WrongSeason, "Wrong season");
++                    }
++
++                    _logger.Debug("Anime multi-season release {0} accepted for anime season search", subject.Release.Title);
++                    return DownloadSpecDecision.Accept();
++                }
++
+                 _logger.Debug("Multi-season release {0} rejected. Not supported", subject.Release.Title);
+                 return DownloadSpecDecision.Reject(DownloadRejectionReason.MultiSeason, "Multi-season releases are not supported");
+             }
+diff --git a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+index cc54dc1cb72df8097176d88b7a3ee2e548c31c29..6b171b9e02cdde2ff1294ddf3e0d832609cd8bb0 100644
+--- a/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
++++ b/src/NzbDrone.Core/Download/TrackedDownloads/TrackedDownloadService.cs
+@@ -132,8 +132,11 @@ public TrackedDownload TrackDownload(DownloadClientDefinition downloadClient, Do
+ 
+                 if (historyItems.Any())
+                 {
+-                    var firstHistoryItem = historyItems.First();
+                     var grabbedEvent = historyItems.FirstOrDefault(v => v.EventType == EpisodeHistoryEventType.Grabbed);
++                    var grabbedEpisodeIds = historyItems.Where(v => v.EventType == EpisodeHistoryEventType.Grabbed)
++                        .Select(h => h.EpisodeId)
++                        .Distinct()
++                        .ToList();
+ 
+                     trackedDownload.Indexer = grabbedEvent?.Data?.GetValueOrDefault("indexer");
+                     trackedDownload.Added = grabbedEvent?.Date;
+@@ -144,15 +147,30 @@ public TrackedDownload TrackDownload(DownloadClientDefinition downloadClient, Do
+                     {
+                         // Try parsing the original source title and if that fails, try parsing it as a special
+                         // TODO: Pass the TVDB ID and TVRage IDs in as well so we have a better chance for finding the item
+-                        parsedEpisodeInfo = Parser.Parser.ParseTitle(firstHistoryItem.SourceTitle) ??
+-                                            _parsingService.ParseSpecialEpisodeTitle(parsedEpisodeInfo, firstHistoryItem.SourceTitle, 0, 0, null);
++                        parsedEpisodeInfo = grabbedEvent != null
++                            ? Parser.Parser.ParseTitle(grabbedEvent.SourceTitle) ??
++                              _parsingService.ParseSpecialEpisodeTitle(parsedEpisodeInfo, grabbedEvent.SourceTitle, 0, 0, null)
++                            : null;
+ 
+                         if (parsedEpisodeInfo != null)
+                         {
+                             trackedDownload.RemoteEpisode = _parsingService.Map(parsedEpisodeInfo,
+-                                firstHistoryItem.SeriesId,
+-                                historyItems.Where(v => v.EventType == EpisodeHistoryEventType.Grabbed)
+-                                    .Select(h => h.EpisodeId).Distinct());
++                                grabbedEvent.SeriesId,
++                                grabbedEpisodeIds);
++                        }
++                        else if (grabbedEvent != null)
++                        {
++                            _logger.Debug("Unable to parse download title '{0}', using grab history to build episode info", trackedDownload.DownloadItem.Title);
++
++                            trackedDownload.RemoteEpisode = _parsingService.Map(
++                                new ParsedEpisodeInfo
++                                {
++                                    ReleaseTitle = grabbedEvent.SourceTitle,
++                                    Languages = LanguageParser.ParseLanguages(grabbedEvent.SourceTitle),
++                                    Quality = QualityParser.ParseQuality(grabbedEvent.SourceTitle)
++                                },
++                                grabbedEvent.SeriesId,
++                                grabbedEpisodeIds);
+                         }
+                     }
+ 
+diff --git a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrAPIResource.cs b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrAPIResource.cs
+deleted file mode 100644
+index 36396462607dc1a9d9f212b19623f114db0d1103..0000000000000000000000000000000000000000
+--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrAPIResource.cs
++++ /dev/null
+@@ -1,45 +0,0 @@
+-using System.Collections.Generic;
+-
+-namespace NzbDrone.Core.ImportLists.Sonarr
+-{
+-    public class SonarrSeries
+-    {
+-        public string Title { get; set; }
+-        public string SortTitle { get; set; }
+-        public int TvdbId { get; set; }
+-        public string Overview { get; set; }
+-        public List<MediaCover.MediaCover> Images { get; set; }
+-        public bool Monitored { get; set; }
+-        public int Year { get; set; }
+-        public string TitleSlug { get; set; }
+-        public int QualityProfileId { get; set; }
+-        public int LanguageProfileId { get; set; }
+-        public string RootFolderPath { get; set; }
+-        public List<SonarrSeason> Seasons { get; set; }
+-        public HashSet<int> Tags { get; set; }
+-    }
+-
+-    public class SonarrProfile
+-    {
+-        public string Name { get; set; }
+-        public int Id { get; set; }
+-    }
+-
+-    public class SonarrTag
+-    {
+-        public string Label { get; set; }
+-        public int Id { get; set; }
+-    }
+-
+-    public class SonarrRootFolder
+-    {
+-        public string Path { get; set; }
+-        public int Id { get; set; }
+-    }
+-
+-    public class SonarrSeason
+-    {
+-        public int SeasonNumber { get; set; }
+-        public bool Monitored { get; set; }
+-    }
+-}
+diff --git a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrImport.cs b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrImport.cs
+deleted file mode 100644
+index d06b294f2c28b22e191581a37872c1207bb1197d..0000000000000000000000000000000000000000
+--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrImport.cs
++++ /dev/null
+@@ -1,177 +0,0 @@
+-using System;
+-using System.Collections.Generic;
+-using System.Linq;
+-using FluentValidation.Results;
+-using NLog;
+-using NzbDrone.Common.Extensions;
+-using NzbDrone.Core.Configuration;
+-using NzbDrone.Core.Localization;
+-using NzbDrone.Core.Parser;
+-using NzbDrone.Core.Parser.Model;
+-using NzbDrone.Core.Tv;
+-using NzbDrone.Core.Validation;
+-
+-namespace NzbDrone.Core.ImportLists.Sonarr
+-{
+-    public class SonarrImport : ImportListBase<SonarrSettings>
+-    {
+-        private readonly ISonarrV3Proxy _sonarrV3Proxy;
+-        public override string Name => "Sonarr";
+-
+-        public override ImportListType ListType => ImportListType.Program;
+-        public override TimeSpan MinRefreshInterval => TimeSpan.FromMinutes(5);
+-
+-        public SonarrImport(ISonarrV3Proxy sonarrV3Proxy,
+-                            IImportListStatusService importListStatusService,
+-                            IConfigService configService,
+-                            IParsingService parsingService,
+-                            ILocalizationService localizationService,
+-                            Logger logger)
+-            : base(importListStatusService, configService, parsingService, localizationService, logger)
+-        {
+-            _sonarrV3Proxy = sonarrV3Proxy;
+-        }
+-
+-        public override ImportListFetchResult Fetch()
+-        {
+-            var series = new List<ImportListItemInfo>();
+-            var anyFailure = false;
+-            try
+-            {
+-                var remoteSeries = _sonarrV3Proxy.GetSeries(Settings);
+-
+-                foreach (var item in remoteSeries)
+-                {
+-                    if (Settings.ProfileIds.Any() && !Settings.ProfileIds.Contains(item.QualityProfileId))
+-                    {
+-                        continue;
+-                    }
+-
+-                    if (Settings.LanguageProfileIds.Any() && !Settings.LanguageProfileIds.Contains(item.LanguageProfileId))
+-                    {
+-                        continue;
+-                    }
+-
+-                    if (Settings.TagIds.Any() && !Settings.TagIds.Any(tagId => item.Tags.Any(itemTagId => itemTagId == tagId)))
+-                    {
+-                        continue;
+-                    }
+-
+-                    if (Settings.RootFolderPaths.Any() && !Settings.RootFolderPaths.Any(rootFolderPath => item.RootFolderPath.ContainsIgnoreCase(rootFolderPath)))
+-                    {
+-                        continue;
+-                    }
+-
+-                    var info = new ImportListItemInfo
+-                    {
+-                        TvdbId = item.TvdbId,
+-                        Title = item.Title
+-                    };
+-
+-                    if (Settings.SyncSeasonMonitoring)
+-                    {
+-                        info.Seasons = item.Seasons.Select(s => new Season
+-                        {
+-                            SeasonNumber = s.SeasonNumber,
+-                            Monitored = s.Monitored
+-                        }).ToList();
+-                    }
+-
+-                    series.Add(info);
+-                }
+-
+-                _importListStatusService.RecordSuccess(Definition.Id);
+-            }
+-            catch (Exception ex)
+-            {
+-                _logger.Debug(ex, "Failed to fetch data for list {0} ({1})", Definition.Name, Name);
+-
+-                _importListStatusService.RecordFailure(Definition.Id);
+-                anyFailure = true;
+-            }
+-
+-            return new ImportListFetchResult(CleanupListItems(series), anyFailure);
+-        }
+-
+-        public override object RequestAction(string action, IDictionary<string, string> query)
+-        {
+-            // Return early if there is not an API key
+-            if (Settings.ApiKey.IsNullOrWhiteSpace())
+-            {
+-                return new
+-                {
+-                    devices = new List<object>()
+-                };
+-            }
+-
+-            Settings.Validate().Filter("ApiKey").ThrowOnError();
+-
+-            if (action == "getProfiles")
+-            {
+-                var profiles = _sonarrV3Proxy.GetQualityProfiles(Settings);
+-
+-                return new
+-                {
+-                    options = profiles.OrderBy(d => d.Name, StringComparer.InvariantCultureIgnoreCase)
+-                        .Select(d => new
+-                        {
+-                            value = d.Id,
+-                            name = d.Name
+-                        })
+-                };
+-            }
+-
+-            if (action == "getLanguageProfiles")
+-            {
+-                var langProfiles = _sonarrV3Proxy.GetLanguageProfiles(Settings);
+-
+-                return new
+-                {
+-                    options = langProfiles.OrderBy(d => d.Name, StringComparer.InvariantCultureIgnoreCase)
+-                        .Select(d => new
+-                        {
+-                            value = d.Id,
+-                            name = d.Name
+-                        })
+-                };
+-            }
+-
+-            if (action == "getTags")
+-            {
+-                var tags = _sonarrV3Proxy.GetTags(Settings);
+-
+-                return new
+-                {
+-                    options = tags.OrderBy(d => d.Label, StringComparer.InvariantCultureIgnoreCase)
+-                        .Select(d => new
+-                        {
+-                            value = d.Id,
+-                            name = d.Label
+-                        })
+-                };
+-            }
+-
+-            if (action == "getRootFolders")
+-            {
+-                var remoteRootFolders = _sonarrV3Proxy.GetRootFolders(Settings);
+-
+-                return new
+-                {
+-                    options = remoteRootFolders.OrderBy(d => d.Path, StringComparer.InvariantCultureIgnoreCase)
+-                        .Select(d => new
+-                        {
+-                            value = d.Path,
+-                            name = d.Path
+-                        })
+-                };
+-            }
+-
+-            return new { };
+-        }
+-
+-        protected override void Test(List<ValidationFailure> failures)
+-        {
+-            failures.AddIfNotNull(_sonarrV3Proxy.Test(Settings));
+-        }
+-    }
+-}
+diff --git a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrSettings.cs b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrSettings.cs
+deleted file mode 100644
+index af1bbd0f77aedc6fcf2703ed99b1de86885f0232..0000000000000000000000000000000000000000
+--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrSettings.cs
++++ /dev/null
+@@ -1,58 +0,0 @@
+-using System;
+-using System.Collections.Generic;
+-using FluentValidation;
+-using NzbDrone.Core.Annotations;
+-using NzbDrone.Core.Validation;
+-
+-namespace NzbDrone.Core.ImportLists.Sonarr
+-{
+-    public class SonarrSettingsValidator : AbstractValidator<SonarrSettings>
+-    {
+-        public SonarrSettingsValidator()
+-        {
+-            RuleFor(c => c.BaseUrl).ValidRootUrl();
+-            RuleFor(c => c.ApiKey).NotEmpty();
+-        }
+-    }
+-
+-    public class SonarrSettings : ImportListSettingsBase<SonarrSettings>
+-    {
+-        private static readonly SonarrSettingsValidator Validator = new ();
+-
+-        public SonarrSettings()
+-        {
+-            ApiKey = "";
+-            ProfileIds = Array.Empty<int>();
+-            LanguageProfileIds = Array.Empty<int>();
+-            TagIds = Array.Empty<int>();
+-            RootFolderPaths = Array.Empty<string>();
+-        }
+-
+-        [FieldDefinition(0, Label = "ImportListsSonarrSettingsFullUrl", HelpText = "ImportListsSonarrSettingsFullUrlHelpText")]
+-        public override string BaseUrl { get; set; } = string.Empty;
+-
+-        [FieldDefinition(1, Label = "ApiKey", HelpText = "ImportListsSonarrSettingsApiKeyHelpText")]
+-        public string ApiKey { get; set; }
+-
+-        [FieldDefinition(2, Label = "ImportListsSonarrSettingsSyncSeasonMonitoring", HelpText = "ImportListsSonarrSettingsSyncSeasonMonitoringHelpText", Type = FieldType.Checkbox)]
+-        public bool SyncSeasonMonitoring { get; set; }
+-
+-        [FieldDefinition(3, Type = FieldType.Select, SelectOptionsProviderAction = "getProfiles", Label = "QualityProfiles", HelpText = "ImportListsSonarrSettingsQualityProfilesHelpText")]
+-        public IEnumerable<int> ProfileIds { get; set; }
+-
+-        [FieldDefinition(4, Type = FieldType.Select, SelectOptionsProviderAction = "getTags", Label = "Tags", HelpText = "ImportListsSonarrSettingsTagsHelpText")]
+-        public IEnumerable<int> TagIds { get; set; }
+-
+-        [FieldDefinition(5, Type = FieldType.Select, SelectOptionsProviderAction = "getRootFolders", Label = "RootFolders", HelpText = "ImportListsSonarrSettingsRootFoldersHelpText")]
+-        public IEnumerable<string> RootFolderPaths { get; set; }
+-
+-        // TODO: Remove this eventually, no translation added as deprecated
+-        [FieldDefinition(6, Type = FieldType.Select, SelectOptionsProviderAction = "getLanguageProfiles", Label = "Language Profiles", HelpText = "Language Profiles from the source instance to import from")]
+-        public IEnumerable<int> LanguageProfileIds { get; set; }
+-
+-        public override NzbDroneValidationResult Validate()
+-        {
+-            return new NzbDroneValidationResult(Validator.Validate(this));
+-        }
+-    }
+-}
+diff --git a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrV3Proxy.cs b/src/NzbDrone.Core/ImportLists/Sonarr/SonarrV3Proxy.cs
+deleted file mode 100644
+index 2913dae9b16a47bc5bbe16b483708e9c45f41655..0000000000000000000000000000000000000000
+--- a/src/NzbDrone.Core/ImportLists/Sonarr/SonarrV3Proxy.cs
++++ /dev/null
+@@ -1,119 +0,0 @@
+-using System;
+-using System.Collections.Generic;
+-using System.Net;
+-using FluentValidation.Results;
+-using Newtonsoft.Json;
+-using NLog;
+-using NzbDrone.Common.Extensions;
+-using NzbDrone.Common.Http;
+-using NzbDrone.Core.Localization;
+-
+-namespace NzbDrone.Core.ImportLists.Sonarr
+-{
+-    public interface ISonarrV3Proxy
+-    {
+-        List<SonarrSeries> GetSeries(SonarrSettings settings);
+-        List<SonarrProfile> GetQualityProfiles(SonarrSettings settings);
+-        List<SonarrProfile> GetLanguageProfiles(SonarrSettings settings);
+-        List<SonarrRootFolder> GetRootFolders(SonarrSettings settings);
+-        List<SonarrTag> GetTags(SonarrSettings settings);
+-        ValidationFailure Test(SonarrSettings settings);
+-    }
+-
+-    public class SonarrV3Proxy : ISonarrV3Proxy
+-    {
+-        private readonly IHttpClient _httpClient;
+-        private readonly Logger _logger;
+-        private readonly ILocalizationService _localizationService;
+-
+-        public SonarrV3Proxy(IHttpClient httpClient, ILocalizationService localizationService, Logger logger)
+-        {
+-            _httpClient = httpClient;
+-            _localizationService = localizationService;
+-            _logger = logger;
+-        }
+-
+-        public List<SonarrSeries> GetSeries(SonarrSettings settings)
+-        {
+-            return Execute<SonarrSeries>("/api/v3/series", settings);
+-        }
+-
+-        public List<SonarrProfile> GetQualityProfiles(SonarrSettings settings)
+-        {
+-            return Execute<SonarrProfile>("/api/v3/qualityprofile", settings);
+-        }
+-
+-        public List<SonarrProfile> GetLanguageProfiles(SonarrSettings settings)
+-        {
+-            return Execute<SonarrProfile>("/api/v3/languageprofile", settings);
+-        }
+-
+-        public List<SonarrRootFolder> GetRootFolders(SonarrSettings settings)
+-        {
+-            return Execute<SonarrRootFolder>("api/v3/rootfolder", settings);
+-        }
+-
+-        public List<SonarrTag> GetTags(SonarrSettings settings)
+-        {
+-            return Execute<SonarrTag>("/api/v3/tag", settings);
+-        }
+-
+-        public ValidationFailure Test(SonarrSettings settings)
+-        {
+-            try
+-            {
+-                GetSeries(settings);
+-            }
+-            catch (HttpException ex)
+-            {
+-                if (ex.Response.StatusCode == HttpStatusCode.Unauthorized)
+-                {
+-                    _logger.Error(ex, "API Key is invalid");
+-                    return new ValidationFailure("ApiKey", _localizationService.GetLocalizedString("ImportListsValidationInvalidApiKey"));
+-                }
+-
+-                if (ex.Response.HasHttpRedirect)
+-                {
+-                    _logger.Error(ex, "Sonarr returned redirect and is invalid");
+-                    return new ValidationFailure("BaseUrl", _localizationService.GetLocalizedString("ImportListsSonarrValidationInvalidUrl"));
+-                }
+-
+-                _logger.Error(ex, "Unable to connect to import list.");
+-                return new ValidationFailure(string.Empty, _localizationService.GetLocalizedString("ImportListsValidationUnableToConnectException", new Dictionary<string, object> { { "exceptionMessage", ex.Message } }));
+-            }
+-            catch (Exception ex)
+-            {
+-                _logger.Error(ex, "Unable to connect to import list.");
+-                return new ValidationFailure(string.Empty, _localizationService.GetLocalizedString("ImportListsValidationUnableToConnectException", new Dictionary<string, object> { { "exceptionMessage", ex.Message } }));
+-            }
+-
+-            return null;
+-        }
+-
+-        private List<TResource> Execute<TResource>(string resource, SonarrSettings settings)
+-        {
+-            if (settings.BaseUrl.IsNullOrWhiteSpace() || settings.ApiKey.IsNullOrWhiteSpace())
+-            {
+-                return new List<TResource>();
+-            }
+-
+-            var baseUrl = settings.BaseUrl.TrimEnd('/');
+-
+-            var request = new HttpRequestBuilder(baseUrl).Resource(resource)
+-                .Accept(HttpAccept.Json)
+-                .SetHeader("X-Api-Key", settings.ApiKey)
+-                .Build();
+-
+-            var response = _httpClient.Get(request);
+-
+-            if ((int)response.StatusCode >= 300)
+-            {
+-                throw new HttpException(response);
+-            }
+-
+-            var results = JsonConvert.DeserializeObject<List<TResource>>(response.Content);
+-
+-            return results;
+-        }
+-    }
+-}
+diff --git a/src/NzbDrone.Core/IndexerSearch/Definitions/AnimeSeasonSearchCriteria.cs b/src/NzbDrone.Core/IndexerSearch/Definitions/AnimeSeasonSearchCriteria.cs
+index efd510f3dc2d4ae8060044b697e1ecd9177172ac..ac9cc2219d28b4e046e0dda96e6a04058cac7817 100644
+--- a/src/NzbDrone.Core/IndexerSearch/Definitions/AnimeSeasonSearchCriteria.cs
++++ b/src/NzbDrone.Core/IndexerSearch/Definitions/AnimeSeasonSearchCriteria.cs
+@@ -1,9 +1,17 @@
++using System.Collections.Generic;
++
+ namespace NzbDrone.Core.IndexerSearch.Definitions
+ {
+     public class AnimeSeasonSearchCriteria : SearchCriteriaBase
+     {
+         public int SeasonNumber { get; set; }
+ 
++        /// <summary>
++        /// Snapshot of broad title-only queries already emitted earlier in this series search.
++        /// Request generators should treat this as read-only state.
++        /// </summary>
++        public IReadOnlyCollection<string> BroadQueriesEmitted { get; set; }
++
+         public override string ToString()
+         {
+             return $"[{Series.Title} : S{SeasonNumber:00}]";
+diff --git a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+index 6625015c7e91a26663c1a9e832967ce03fc56674..5725b99234c6b0605d98f8444eddd8cc5d0e5152 100644
+--- a/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
++++ b/src/NzbDrone.Core/IndexerSearch/ReleaseSearchService.cs
+@@ -23,6 +23,7 @@ public interface ISearchForReleases
+         Task<List<DownloadDecision>> EpisodeSearch(Episode episode, bool userInvokedSearch, bool interactiveSearch);
+         Task<List<DownloadDecision>> SeasonSearch(int seriesId, int seasonNumber, bool missingOnly, bool monitoredOnly, bool userInvokedSearch, bool interactiveSearch);
+         Task<List<DownloadDecision>> SeasonSearch(int seriesId, int seasonNumber, List<Episode> episodes, bool monitoredOnly, bool userInvokedSearch, bool interactiveSearch);
++        Task<List<DownloadDecision>> SeasonSearch(int seriesId, int seasonNumber, bool missingOnly, bool monitoredOnly, bool userInvokedSearch, bool interactiveSearch, HashSet<string> animeBroadQueriesEmitted, HashSet<int> alreadyCoveredEpisodeIds = null);
+     }
+ 
+     public class ReleaseSearchService : ISearchForReleases
+@@ -94,6 +95,11 @@ public async Task<List<DownloadDecision>> EpisodeSearch(Episode episode, bool us
+         }
+ 
+         public async Task<List<DownloadDecision>> SeasonSearch(int seriesId, int seasonNumber, bool missingOnly, bool monitoredOnly, bool userInvokedSearch, bool interactiveSearch)
++        {
++            return await SeasonSearch(seriesId, seasonNumber, missingOnly, monitoredOnly, userInvokedSearch, interactiveSearch, null);
++        }
++
++        public async Task<List<DownloadDecision>> SeasonSearch(int seriesId, int seasonNumber, bool missingOnly, bool monitoredOnly, bool userInvokedSearch, bool interactiveSearch, HashSet<string> animeBroadQueriesEmitted, HashSet<int> alreadyCoveredEpisodeIds = null)
+         {
+             var episodes = _episodeService.GetEpisodesBySeason(seriesId, seasonNumber);
+ 
+@@ -102,16 +108,29 @@ public async Task<List<DownloadDecision>> SeasonSearch(int seriesId, int seasonN
+                 episodes = episodes.Where(e => !e.HasFile).ToList();
+             }
+ 
+-            return await SeasonSearch(seriesId, seasonNumber, episodes, monitoredOnly, userInvokedSearch, interactiveSearch);
++            return await SeasonSearch(seriesId, seasonNumber, episodes, monitoredOnly, userInvokedSearch, interactiveSearch, animeBroadQueriesEmitted, alreadyCoveredEpisodeIds);
+         }
+ 
+         public async Task<List<DownloadDecision>> SeasonSearch(int seriesId, int seasonNumber, List<Episode> episodes, bool monitoredOnly, bool userInvokedSearch, bool interactiveSearch)
++        {
++            return await SeasonSearch(seriesId, seasonNumber, episodes, monitoredOnly, userInvokedSearch, interactiveSearch, null);
++        }
++
++        private async Task<List<DownloadDecision>> SeasonSearch(int seriesId, int seasonNumber, List<Episode> episodes, bool monitoredOnly, bool userInvokedSearch, bool interactiveSearch, HashSet<string> animeBroadQueriesEmitted, HashSet<int> alreadyCoveredEpisodeIds = null)
+         {
+             var series = _seriesService.GetSeries(seriesId);
+ 
+             if (series.SeriesType == SeriesTypes.Anime)
+             {
+-                return await SearchAnimeSeason(series, episodes, monitoredOnly, userInvokedSearch, interactiveSearch);
++                // Season 0 specials use the special search path to avoid
++                // the anime season-pack fallback misclassifying bare-title packs.
++                if (seasonNumber == 0)
++                {
++                    _logger.Debug("Anime cascade: Season 0 of {0} — routing to special search path", series.Title);
++                    return await SearchSpecial(series, episodes, monitoredOnly, userInvokedSearch, interactiveSearch);
++                }
++
++                return await SearchAnimeSeason(series, episodes, monitoredOnly, userInvokedSearch, interactiveSearch, animeBroadQueriesEmitted, alreadyCoveredEpisodeIds);
+             }
+ 
+             if (series.SeriesType == SeriesTypes.Daily)
+@@ -374,22 +393,48 @@ private async Task<List<DownloadDecision>> SearchSpecial(Series series, List<Epi
+ 
+             downloadDecisions.AddRange(await Dispatch(indexer => indexer.Fetch(searchSpec), searchSpec));
+ 
+-            // Search for each episode by season/episode number as well
+-            foreach (var episode in episodes)
++            // Determine which episodes still need per-episode fallback
++            var episodesToSearch = episodes
++                .Where(e => interactiveSearch || !monitoredOnly || e.Monitored)
++                .ToList();
++
++            // Collect episode IDs covered by approved special-search results
++            var coveredEpisodeIds = new HashSet<int>(
++                downloadDecisions
++                    .Where(d => d.Approved)
++                    .SelectMany(d => d.RemoteEpisode.Episodes)
++                    .Select(e => e.Id));
++
++            var uncoveredEpisodes = episodesToSearch
++                .Where(ep => !coveredEpisodeIds.Contains(ep.Id))
++                .ToList();
++
++            if (uncoveredEpisodes.Any())
+             {
+-                // Episode needs to be monitored if it's not an interactive search
+-                if (!interactiveSearch && monitoredOnly && !episode.Monitored)
++                _logger.Debug(
++                    "Anime cascade [{0} Season 0]: {1}/{2} specials covered by approved special-search results, searching {3} uncovered specials individually",
++                    series.Title,
++                    episodesToSearch.Count - uncoveredEpisodes.Count,
++                    episodesToSearch.Count,
++                    uncoveredEpisodes.Count);
++
++                foreach (var episode in uncoveredEpisodes)
+                 {
+-                    continue;
++                    downloadDecisions.AddRange(await SearchSingle(series, episode, monitoredOnly, userInvokedSearch, interactiveSearch));
+                 }
+-
+-                downloadDecisions.AddRange(await SearchSingle(series, episode, monitoredOnly, userInvokedSearch, interactiveSearch));
++            }
++            else if (episodesToSearch.Any())
++            {
++                _logger.Debug(
++                    "Anime cascade [{0} Season 0]: all {1} specials covered by approved special-search results, skipping per-episode search",
++                    series.Title,
++                    episodesToSearch.Count);
+             }
+ 
+             return DeDupeDecisions(downloadDecisions);
+         }
+ 
+-        private async Task<List<DownloadDecision>> SearchAnimeSeason(Series series, List<Episode> episodes, bool monitoredOnly, bool userInvokedSearch, bool interactiveSearch)
++        private async Task<List<DownloadDecision>> SearchAnimeSeason(Series series, List<Episode> episodes, bool monitoredOnly, bool userInvokedSearch, bool interactiveSearch, HashSet<string> animeBroadQueriesEmitted = null, HashSet<int> alreadyCoveredEpisodeIds = null)
+         {
+             var downloadDecisions = new List<DownloadDecision>();
+ 
+@@ -410,14 +455,73 @@ private async Task<List<DownloadDecision>> SearchAnimeSeason(Series series, List
+             foreach (var season in seasonsToSearch)
+             {
+                 searchSpec.SeasonNumber = season.SeasonNumber;
++                searchSpec.BroadQueriesEmitted = animeBroadQueriesEmitted?.ToArray();
+ 
+                 var decisions = await Dispatch(indexer => indexer.Fetch(searchSpec), searchSpec);
+                 downloadDecisions.AddRange(decisions);
++
++                if (animeBroadQueriesEmitted != null)
++                {
++                    animeBroadQueriesEmitted.UnionWith(searchSpec.SceneTitles);
++                }
++            }
++
++            // Collect episode IDs covered by approved season search results
++            var coveredEpisodeIds = new HashSet<int>(
++                downloadDecisions
++                    .Where(d => d.Approved)
++                    .SelectMany(d => d.RemoteEpisode.Episodes)
++                    .Select(e => e.Id));
++
++            // Merge in episodes already covered by earlier season grabs (cross-season coverage)
++            if (alreadyCoveredEpisodeIds != null && alreadyCoveredEpisodeIds.Count > 0)
++            {
++                var crossSeasonCovered = episodesToSearch.Count(ep => alreadyCoveredEpisodeIds.Contains(ep.Id));
++
++                if (crossSeasonCovered > 0)
++                {
++                    _logger.Debug(
++                        "Anime cascade [{0} Season {1}]: {2} episodes already covered by earlier season grabs",
++                        series.Title,
++                        episodes.FirstOrDefault()?.SeasonNumber,
++                        crossSeasonCovered);
++                }
++
++                coveredEpisodeIds.UnionWith(alreadyCoveredEpisodeIds);
+             }
+ 
+-            foreach (var episode in episodesToSearch)
++            // Only search for episodes not already covered by an approved season result
++            // or by earlier cross-season grabs
++            var uncoveredEpisodes = episodesToSearch
++                .Where(ep => !coveredEpisodeIds.Contains(ep.Id))
++                .ToList();
++
++            if (uncoveredEpisodes.Any())
++            {
++                var seasonNum = episodes.FirstOrDefault()?.SeasonNumber;
++
++                _logger.Debug(
++                    "Anime cascade [{0} Season {1}]: {2}/{3} episodes covered (season results: {4}, cross-season grabs: {5}), searching {6} uncovered episodes individually",
++                    series.Title,
++                    seasonNum,
++                    episodesToSearch.Count - uncoveredEpisodes.Count,
++                    episodesToSearch.Count,
++                    downloadDecisions.Count(d => d.Approved),
++                    alreadyCoveredEpisodeIds?.Count(id => episodesToSearch.Any(ep => ep.Id == id)) ?? 0,
++                    uncoveredEpisodes.Count);
++
++                foreach (var episode in uncoveredEpisodes)
++                {
++                    downloadDecisions.AddRange(await SearchAnime(series, episode, monitoredOnly, userInvokedSearch, interactiveSearch, true));
++                }
++            }
++            else
+             {
+-                downloadDecisions.AddRange(await SearchAnime(series, episode, monitoredOnly, userInvokedSearch, interactiveSearch, true));
++                _logger.Debug(
++                    "Anime cascade [{0} Season {1}]: all {2} episodes covered by approved results, skipping per-episode search",
++                    series.Title,
++                    episodes.FirstOrDefault()?.SeasonNumber,
++                    episodesToSearch.Count);
+             }
+ 
+             return DeDupeDecisions(downloadDecisions);
+diff --git a/src/NzbDrone.Core/IndexerSearch/SeriesSearchService.cs b/src/NzbDrone.Core/IndexerSearch/SeriesSearchService.cs
+index 4f4f6b9adb65fdd02f1d7c802d3b1f7ae4068e3c..6cc34e308fe167a9b7b5d895b8d00223b59f3beb 100644
+--- a/src/NzbDrone.Core/IndexerSearch/SeriesSearchService.cs
++++ b/src/NzbDrone.Core/IndexerSearch/SeriesSearchService.cs
+@@ -1,4 +1,5 @@
+ using System;
++using System.Collections.Generic;
+ using System.Linq;
+ using NLog;
+ using NzbDrone.Common.Extensions;
+@@ -54,6 +55,79 @@ public void Execute(SeriesSearchCommand message)
+                     downloadedCount += processDecisions.Grabbed.Count;
+                 }
+             }
++            else if (series.SeriesType == SeriesTypes.Anime)
++            {
++                var coveredEpisodeIds = new HashSet<int>();
++                var broadQueriesEmitted = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
++
++                // Search non-zero seasons first so a grabbed pack (e.g. S01+Specials)
++                // can cover Season 0 specials before we search for them separately.
++                foreach (var season in series.Seasons
++                    .OrderBy(s => s.SeasonNumber == 0 ? 1 : 0)
++                    .ThenBy(s => s.SeasonNumber))
++                {
++                    if (!season.Monitored)
++                    {
++                        _logger.Debug("Season {0} of {1} is not monitored, skipping search", season.SeasonNumber, series.Title);
++                        continue;
++                    }
++
++                    // Check if all monitored, aired, missing episodes in this season are already covered
++                    var seasonEpisodes = _episodeService.GetEpisodesBySeason(series.Id, season.SeasonNumber);
++                    var wantedEpisodes = seasonEpisodes
++                        .Where(e => e.Monitored &&
++                                    !e.HasFile &&
++                                    e.AirDateUtc.HasValue &&
++                                    e.AirDateUtc.Value.Before(DateTime.UtcNow))
++                        .ToList();
++
++                    if (wantedEpisodes.Any() && wantedEpisodes.All(e => coveredEpisodeIds.Contains(e.Id)))
++                    {
++                        _logger.Debug(
++                            "Anime cascade [{0} Season {1}]: all {2} wanted episodes already covered by earlier grabs, skipping season search",
++                            series.Title,
++                            season.SeasonNumber,
++                            wantedEpisodes.Count);
++                        continue;
++                    }
++
++                    if (wantedEpisodes.Any())
++                    {
++                        var alreadyCovered = wantedEpisodes.Count(e => coveredEpisodeIds.Contains(e.Id));
++
++                        if (alreadyCovered > 0)
++                        {
++                            _logger.Debug(
++                                "Anime cascade [{0} Season {1}]: {2}/{3} wanted episodes already covered by earlier grabs, searching season with partial coverage",
++                                series.Title,
++                                season.SeasonNumber,
++                                alreadyCovered,
++                                wantedEpisodes.Count);
++                        }
++                    }
++
++                    var decisions = _releaseSearchService.SeasonSearch(
++                        message.SeriesId,
++                        season.SeasonNumber,
++                        false,
++                        true,
++                        userInvokedSearch,
++                        false,
++                        broadQueriesEmitted,
++                        coveredEpisodeIds).GetAwaiter().GetResult();
++                    var processDecisions = _processDownloadDecisions.ProcessDecisions(decisions).GetAwaiter().GetResult();
++                    downloadedCount += processDecisions.Grabbed.Count;
++
++                    // Track episode IDs from grabbed results for cross-season skipping
++                    foreach (var grabbed in processDecisions.Grabbed)
++                    {
++                        foreach (var ep in grabbed.RemoteEpisode.Episodes)
++                        {
++                            coveredEpisodeIds.Add(ep.Id);
++                        }
++                    }
++                }
++            }
+             else
+             {
+                 foreach (var season in series.Seasons.OrderBy(s => s.SeasonNumber))
+diff --git a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+index 43a9516ee9cd46a7915b808d39096db0ab9ab3b5..f7f827a35820b41b426543076b37c7a7ddd26c63 100644
+--- a/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
++++ b/src/NzbDrone.Core/Indexers/Newznab/NewznabRequestGenerator.cs
+@@ -447,21 +447,61 @@ public virtual IndexerPageableRequestChain GetSearchRequests(AnimeSeasonSearchCr
+         {
+             var pageableRequests = new IndexerPageableRequestChain();
+ 
+-            if (SupportsSearch && Settings.AnimeStandardFormatSearch && searchCriteria.SeasonNumber > 0)
++            if (!SupportsSearch)
++            {
++                return pageableRequests;
++            }
++
++            var queryTitles = TextSearchEngine == "raw" ? searchCriteria.AllSceneTitles : searchCriteria.CleanSceneTitles;
++            var emitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
++
++            // Build suppression set from BroadQueriesEmitted using the same title normalization
++            HashSet<string> broadAlreadyEmitted = null;
++            if (searchCriteria.BroadQueriesEmitted != null)
++            {
++                broadAlreadyEmitted = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
++                foreach (var title in searchCriteria.BroadQueriesEmitted)
++                {
++                    broadAlreadyEmitted.Add(NewsnabifyTitle(title));
++                    broadAlreadyEmitted.Add(NewsnabifyTitle(SearchCriteriaBase.GetCleanSceneTitle(title)));
++                }
++            }
++
++            // Broad title-only queries to catch batch/pack releases (emitted first)
++            foreach (var queryTitle in queryTitles)
++            {
++                var normalized = NewsnabifyTitle(queryTitle);
++                var alreadySuppressed = broadAlreadyEmitted != null && broadAlreadyEmitted.Contains(normalized);
++
++                if (!alreadySuppressed && emitted.Add(normalized))
++                {
++                    pageableRequests.Add(GetPagedRequests(MaxPages,
++                        Settings.AnimeCategories,
++                        "search",
++                        $"&q={normalized}"));
++                }
++            }
++
++            // Season-specific queries (existing behavior, gated on AnimeStandardFormatSearch)
++            if (Settings.AnimeStandardFormatSearch && searchCriteria.SeasonNumber > 0)
+             {
+                 AddTvIdPageableRequests(pageableRequests,
+                     Settings.AnimeCategories,
+                     searchCriteria,
+                     $"&season={NewznabifySeasonNumber(searchCriteria.SeasonNumber)}");
+ 
+-                var queryTitles = TextSearchEngine == "raw" ? searchCriteria.AllSceneTitles : searchCriteria.CleanSceneTitles;
+-
+                 foreach (var queryTitle in queryTitles)
+                 {
+-                    pageableRequests.Add(GetPagedRequests(MaxPages,
+-                        Settings.AnimeCategories,
+-                        "tvsearch",
+-                        $"&q={NewsnabifyTitle(queryTitle)}&season={NewznabifySeasonNumber(searchCriteria.SeasonNumber)}"));
++                    var normalized = NewsnabifyTitle(queryTitle);
++                    var seasonKey = $"{normalized}|s{searchCriteria.SeasonNumber}";
++
++                    if (emitted.Add(seasonKey))
++                    {
++                        pageableRequests.Add(GetPagedRequests(MaxPages,
++                            Settings.AnimeCategories,
++                            "tvsearch",
++                            $"&q={normalized}&season={NewznabifySeasonNumber(searchCriteria.SeasonNumber)}"));
++                    }
+                 }
+             }
+ 
+diff --git a/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs b/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
+index 92e9d6254a841da4a237c7b6c705a711a12fdd68..4a40eca3f05b867f5ea0376a3e66183618ba0811 100644
+--- a/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
++++ b/src/NzbDrone.Core/Indexers/Nyaa/NyaaRequestGenerator.cs
+@@ -2,6 +2,7 @@
+ using System.Linq;
+ using NzbDrone.Common.Http;
+ using NzbDrone.Core.IndexerSearch.Definitions;
++using NzbDrone.Core.Tv;
+ 
+ namespace NzbDrone.Core.Indexers.Nyaa
+ {
+@@ -22,7 +23,7 @@ public virtual IndexerPageableRequestChain GetSearchRequests(SingleEpisodeSearch
+         {
+             var pageableRequests = new IndexerPageableRequestChain();
+ 
+-            if (Settings.AnimeStandardFormatSearch && searchCriteria.SeasonNumber > 0 && searchCriteria.EpisodeNumber > 0)
++            if (Settings.AnimeStandardFormatSearch && searchCriteria.SeasonNumber >= 0 && searchCriteria.EpisodeNumber > 0)
+             {
+                 foreach (var searchTitle in searchCriteria.SceneTitles.Select(PrepareQuery))
+                 {
+@@ -86,12 +87,32 @@ public virtual IndexerPageableRequestChain GetSearchRequests(AnimeEpisodeSearchC
+         public virtual IndexerPageableRequestChain GetSearchRequests(AnimeSeasonSearchCriteria searchCriteria)
+         {
+             var pageableRequests = new IndexerPageableRequestChain();
++            var emitted = new HashSet<string>();
++            var broadQueriesEmitted = searchCriteria.BroadQueriesEmitted == null
++                ? null
++                : new HashSet<string>(searchCriteria.BroadQueriesEmitted.Select(PrepareQuery));
+ 
+             foreach (var searchTitle in searchCriteria.SceneTitles.Select(PrepareQuery))
+             {
++                // Broad title-only query to catch batch/pack releases without season markers.
++                // If a series-level snapshot is provided, skip broad queries
++                // already emitted by an earlier season search in the same series search.
++                var alreadyEmittedBroad = broadQueriesEmitted != null &&
++                                          broadQueriesEmitted.Contains(searchTitle);
++
++                if (!alreadyEmittedBroad && emitted.Add(searchTitle))
++                {
++                    pageableRequests.Add(GetPagedRequests(searchTitle));
++                }
++
+                 if (Settings.AnimeStandardFormatSearch && searchCriteria.SeasonNumber > 0)
+                 {
+-                    pageableRequests.Add(GetPagedRequests($"{searchTitle}+s{searchCriteria.SeasonNumber:00}"));
++                    var seasonTerm = $"{searchTitle}+s{searchCriteria.SeasonNumber:00}";
++
++                    if (emitted.Add(seasonTerm))
++                    {
++                        pageableRequests.Add(GetPagedRequests(seasonTerm));
++                    }
+                 }
+             }
+ 
+@@ -107,6 +128,25 @@ public virtual IndexerPageableRequestChain GetSearchRequests(SpecialEpisodeSearc
+                 pageableRequests.Add(GetPagedRequests(PrepareQuery(queryTitle)));
+             }
+ 
++            // Anime special searches: add conservative OVA/Special alias queries
++            if (searchCriteria.Series?.SeriesType == SeriesTypes.Anime)
++            {
++                var emitted = new HashSet<string>();
++
++                foreach (var searchTitle in searchCriteria.SceneTitles.Select(PrepareQuery))
++                {
++                    foreach (var alias in new[] { "ova", "oav", "special", "specials" })
++                    {
++                        var term = $"{searchTitle}+{alias}";
++
++                        if (emitted.Add(term))
++                        {
++                            pageableRequests.Add(GetPagedRequests(term));
++                        }
++                    }
++                }
++            }
++
+             return pageableRequests;
+         }
+ 
+diff --git a/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs b/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
+index f1a7bdcb43d246b3e1b2e9c9ccc0f867c214261c..838f3487025a0a0904301a79747e5f2e18fda412 100644
+--- a/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
++++ b/src/NzbDrone.Core/Parser/Model/ParsedEpisodeInfo.cs
+@@ -22,6 +22,7 @@ public class ParsedEpisodeInfo
+         public bool FullSeason { get; set; }
+         public bool IsPartialSeason { get; set; }
+         public bool IsMultiSeason { get; set; }
++        public int[] SeasonNumbers { get; set; }
+         public bool IsSeasonExtra { get; set; }
+         public bool IsSplitEpisode { get; set; }
+         public bool IsMiniSeries { get; set; }
+@@ -37,6 +38,7 @@ public ParsedEpisodeInfo()
+             EpisodeNumbers = Array.Empty<int>();
+             AbsoluteEpisodeNumbers = Array.Empty<int>();
+             SpecialAbsoluteEpisodeNumbers = Array.Empty<decimal>();
++            SeasonNumbers = Array.Empty<int>();
+             Languages = new List<Language>();
+         }
+ 
+diff --git a/src/NzbDrone.Core/Parser/Parser.cs b/src/NzbDrone.Core/Parser/Parser.cs
+index f94aa081a4f39a23f7a6e530c854aa62a5b8502c..fee0de918cf2051018eb5f127a6c49a6c0cf694b 100644
+--- a/src/NzbDrone.Core/Parser/Parser.cs
++++ b/src/NzbDrone.Core/Parser/Parser.cs
+@@ -131,6 +131,12 @@ public static class Parser
+                 new Regex(@"^\[(?<subgroup>.+?)\][-_. ]?(?<title>[^-]+?)(?:(?<![-_. ]|\b[0]\d+) - )(?:[-_. ]?(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+)))+(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>[(\[]\w{8}[)\]])?(?:$|\.mkv)",
+                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
+ 
++                // Anime - [SubGroup] Title multi-season pack S01-S04 or S01+S02+S03+S04 or (S01+S02+...) (Full season)
++                // Allows optional ( before first S; after the season list, + is only valid when followed by
++                // non-season content (not S, digit, or end-of-string), rejecting malformed tails like S01+S02+, S01+S02+Sx, S01+S02+1
++                new Regex(@"^\[(?<subgroup>.+?)\][-_. ]?(?<title>.+?)[-_. ]+\(?S(?<season>\d{1,2})(?:[-+]S(?<season>\d{1,2}))+(?:[-_. )]+|\+(?!S|\d|$)|$)",
++                    RegexOptions.IgnoreCase | RegexOptions.Compiled),
++
+                 // Anime - [SubGroup] Title with trailing number S## (Full season)
+                 new Regex(@"^\[(?<subgroup>.+?)\][-_. ]?(?<title>.+?)[-_. ]+(?:S(?<season>(?<!\d+)(?:\d{1,2}|\d{4})(?![ex]?\d+))).+?(?:$|\.mkv)",
+                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
+@@ -147,6 +153,10 @@ public static class Parser
+                 new Regex(@"^\[(?<subgroup>.+?)\][-_. ]?(?<title>.+?)(?:(?<!\b[0]\d+))(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+|[-]))[. ]-[. ](?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+|[-]))(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>[(\[]\w{8}[)\]])?(?:$|\.mkv)",
+                     RegexOptions.IgnoreCase | RegexOptions.Compiled),
+ 
++                // Anime - [SubGroup] Title Absolute Episode Number range with dash/tilde (e.g. 1-26, 01-26, 01~26)
++                new Regex(@"^\[(?<subgroup>.+?)\][-_. ]?(?<title>.+?)[-_. ]+(?<absoluteepisode>\d{1,3}(\.\d{1,2})?)(?:[-~]| ~ )(?<absoluteepisode>\d{1,3}(\.\d{1,2})?(?!\d+))(?:[-_. ]+|\[|\(|$).*?(?<hash>[(\[]\w{8}[)\]])?(?:$|\.mkv)",
++                    RegexOptions.IgnoreCase | RegexOptions.Compiled),
++
+                 // Anime - [SubGroup] Title Absolute Episode Number
+                 new Regex(@"^\[(?<subgroup>.+?)\][-_. ]?(?<title>.+?)[-_. ]+\(?(?:[-_. ]?#?(?<absoluteepisode>\d{2,3}(\.\d{1,2})?(?!\d+|-[a-z]+)))+\)?(?:[-_. ]+(?<special>special|ova|ovd))?.*?(?<hash>[(\[]\w{8}[)\]])?(?:$|\.mkv)",
+                           RegexOptions.IgnoreCase | RegexOptions.Compiled),
+@@ -529,7 +539,7 @@ public static class Parser
+         private static readonly Regex FileExtensionRegex = new Regex(@"\.[a-z0-9]{2,4}$",
+                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
+ 
+-        private static readonly RegexReplace SimpleTitleRegex = new RegexReplace(@"(?:(480|540|576|720|1080|2160)[ip]|[xh][\W_]?26[45]|DD\W?5\W1|[<>?*]|848x480|1280x720|1920x1080|3840x2160|4096x2160|(?<![a-f0-9])(8|10)(b(?![a-z0-9])|bit)|10-bit)\s*?",
++        private static readonly RegexReplace SimpleTitleRegex = new RegexReplace(@"(?:(480|540|576|720|1080|2160)[ip]|[xh][\W_]?26[45]|DD\W?5\W1|[<>?*]|848x480|1280x720|1920x1080|3840x2160|4096x2160|(?<![a-f0-9])(8|10)([-_. ]bits?(?=[)\]])|bits?\b|b(?![a-z0-9]))|10-bit)\s*?",
+                                                                 string.Empty,
+                                                                 RegexOptions.IgnoreCase | RegexOptions.Compiled);
+ 
+@@ -772,7 +782,12 @@ public static ParsedEpisodeInfo ParseTitle(string title)
+ 
+                             if (result != null)
+                             {
+-                                if (result.FullSeason && result.ReleaseTokens.ContainsIgnoreCase("Special"))
++                                // Anime multi-season batch packs often include trailing metadata like
++                                // "Movies+Specials+OVAs" which must not downgrade the pack to a special.
++                                // Anime single-season packs that explicitly advertise specials (S01+Specials,
++                                // S01+Special, S01+OVA, S01+OAV) should also remain full-season packs.
++                                if (result.FullSeason && !result.IsMultiSeason && result.ReleaseTokens.ContainsIgnoreCase("Special") &&
++                                    !Regex.IsMatch(releaseTitle, @"S\d{1,2}\s*\+\s*(?:Specials?|OVA|OAV)", RegexOptions.IgnoreCase))
+                                 {
+                                     result.FullSeason = false;
+                                     result.Special = true;
+@@ -1152,6 +1167,20 @@ private static ParsedEpisodeInfo ParseMatchCollection(MatchCollection matchColle
+                 if (seasons.Distinct().Count() > 1)
+                 {
+                     result.IsMultiSeason = true;
++
++                    // Populate SeasonNumbers with all covered seasons
++                    var distinctSeasons = seasons.Distinct().OrderBy(s => s).ToList();
++
++                    if (distinctSeasons.Count == 2 && !Regex.IsMatch(releaseTitle, @"S\d{1,2}\+", RegexOptions.IgnoreCase))
++                    {
++                        // Range separator (S01-S04): expand inclusively
++                        result.SeasonNumbers = Enumerable.Range(distinctSeasons.First(), distinctSeasons.Last() - distinctSeasons.First() + 1).ToArray();
++                    }
++                    else
++                    {
++                        // Explicit list (S01+S02+S04) or 3+ captures: use exact list
++                        result.SeasonNumbers = distinctSeasons.ToArray();
++                    }
+                 }
+ 
+                 if (seasons.Any())
+diff --git a/src/NzbDrone.Core/Parser/ParsingService.cs b/src/NzbDrone.Core/Parser/ParsingService.cs
+index 7cbff94f197eef72b9c526355c486170225ca038..2d7b2dc31a1a92bf0d7343bb66d0a1a00c53893a 100644
+--- a/src/NzbDrone.Core/Parser/ParsingService.cs
++++ b/src/NzbDrone.Core/Parser/ParsingService.cs
+@@ -1,6 +1,7 @@
+ using System;
+ using System.Collections.Generic;
+ using System.Linq;
++using System.Text.RegularExpressions;
+ using NLog;
+ using NzbDrone.Common.Extensions;
+ using NzbDrone.Common.Instrumentation.Extensions;
+@@ -223,18 +224,62 @@ private List<Episode> GetEpisodes(ParsedEpisodeInfo parsedEpisodeInfo, Series se
+         {
+             if (parsedEpisodeInfo.FullSeason)
+             {
+-                if (series.UseSceneNumbering && sceneSource)
+-                {
+-                    var episodes = _episodeService.GetEpisodesBySceneSeason(series.Id, mappedSeasonNumber);
+-
+-                    // If episodes were found by the scene season number return them, otherwise fallback to look-up by season number
+-                    if (episodes.Any())
++                // Anime multi-season pack: return episodes from all covered seasons
++                if (parsedEpisodeInfo.IsMultiSeason &&
++                    parsedEpisodeInfo.SeasonNumbers.Length > 0 &&
++                    series.SeriesType == SeriesTypes.Anime)
++                {
++                    return parsedEpisodeInfo.SeasonNumbers
++                        .SelectMany(s => GetFullSeasonEpisodes(series, s, sceneSource))
++                        .GroupBy(e => e.Id)
++                        .Select(g => g.First())
++                        .ToList();
++                }
++
++                var episodes = GetFullSeasonEpisodes(series, mappedSeasonNumber, sceneSource);
++
++                // For anime single-season packs with explicit special keywords (S01+Specials,
++                // S01+OVA, etc.), co-cover exactly one wanted Season 0 special.
++                if (series.SeriesType == SeriesTypes.Anime &&
++                    mappedSeasonNumber > 0 &&
++                    !parsedEpisodeInfo.IsMultiSeason &&
++                    parsedEpisodeInfo.ReleaseTitle != null &&
++                    Regex.IsMatch(parsedEpisodeInfo.ReleaseTitle, @"\b(?:Specials?|OVA|OAV)\b", RegexOptions.IgnoreCase) &&
++                    !Regex.IsMatch(parsedEpisodeInfo.ReleaseTitle, @"\b(?:Extras?|NCOP|NCED|Menu|Bonus)\b", RegexOptions.IgnoreCase))
++                {
++                    var season0Episodes = _episodeService.GetEpisodesBySeason(series.Id, 0);
++                    var wantedSpecials = season0Episodes
++                        .Where(e => e.Monitored &&
++                                    !e.HasFile &&
++                                    e.AirDateUtc.HasValue &&
++                                    e.AirDateUtc.Value < DateTime.UtcNow)
++                        .ToList();
++
++                    if (wantedSpecials.Count == 1)
++                    {
++                        _logger.Debug(
++                            "Anime cascade: mixed pack '{0}' co-covers Season 0 special S{1:00}E{2:00}",
++                            parsedEpisodeInfo.ReleaseTitle,
++                            wantedSpecials[0].SeasonNumber,
++                            wantedSpecials[0].EpisodeNumber);
++                        episodes.Add(wantedSpecials[0]);
++                    }
++                    else if (wantedSpecials.Count > 1)
+                     {
+-                        return episodes;
++                        _logger.Debug(
++                            "Anime cascade: mixed pack '{0}' has special keywords but {1} wanted specials — co-coverage skipped (only single special supported)",
++                            parsedEpisodeInfo.ReleaseTitle,
++                            wantedSpecials.Count);
++                    }
++                    else
++                    {
++                        _logger.Debug(
++                            "Anime cascade: mixed pack '{0}' has special keywords but no wanted Season 0 specials to co-cover",
++                            parsedEpisodeInfo.ReleaseTitle);
+                     }
+                 }
+ 
+-                return _episodeService.GetEpisodesBySeason(series.Id, mappedSeasonNumber);
++                return episodes;
+             }
+ 
+             if (parsedEpisodeInfo.IsDaily)
+@@ -273,6 +318,22 @@ private List<Episode> GetEpisodes(ParsedEpisodeInfo parsedEpisodeInfo, Series se
+             return GetStandardEpisodes(series, parsedEpisodeInfo, mappedSeasonNumber, sceneSource, searchCriteria);
+         }
+ 
++        private List<Episode> GetFullSeasonEpisodes(Series series, int seasonNumber, bool sceneSource)
++        {
++            if (series.UseSceneNumbering && sceneSource)
++            {
++                var episodes = _episodeService.GetEpisodesBySceneSeason(series.Id, seasonNumber);
++
++                // If episodes were found by the scene season number return them, otherwise fallback to look-up by season number
++                if (episodes.Any())
++                {
++                    return episodes;
++                }
++            }
++
++            return _episodeService.GetEpisodesBySeason(series.Id, seasonNumber);
++        }
++
+         public ParsedEpisodeInfo ParseSpecialEpisodeTitle(ParsedEpisodeInfo parsedEpisodeInfo, string releaseTitle, int tvdbId, int tvRageId, string imdbId, SearchCriteriaBase searchCriteria = null)
+         {
+             if (searchCriteria != null)
+diff --git a/src/NzbDrone.Host/Startup.cs b/src/NzbDrone.Host/Startup.cs
+index 425ec014f90d60811f8459a7c4d8b9ff686e131f..cb90204cbce251c7a44a501b9f370f655deffb0a 100644
+--- a/src/NzbDrone.Host/Startup.cs
++++ b/src/NzbDrone.Host/Startup.cs
+@@ -238,7 +238,14 @@ public void Configure(IApplicationBuilder app,
+ 
+             if (OsInfo.IsNotWindows)
+             {
+-                Console.CancelKeyPress += (sender, eventArgs) => NLog.LogManager.Configuration = null;
++                try
++                {
++                    Console.CancelKeyPress += (sender, eventArgs) => NLog.LogManager.Configuration = null;
++                }
++                catch (TypeInitializationException)
++                {
++                    // Some hosted macOS runners can fail to initialize System.Console; skip the handler in that case.
++                }
+             }
+ 
+             eventAggregator.PublishEvent(new ApplicationStartingEvent());

--- a/.fork/patches/0003-fork-tests.patch
+++ b/.fork/patches/0003-fork-tests.patch
@@ -1,0 +1,3160 @@
+diff --git a/src/NzbDrone.Api.Test/Sonarr.Api.Test.csproj b/src/NzbDrone.Api.Test/Sonarr.Api.Test.csproj
+index 053b42cc9dc6c8965dea7ad6c1ee57180acc7373..b7755139acb9b3cedae6881494419d37fdce3577 100644
+--- a/src/NzbDrone.Api.Test/Sonarr.Api.Test.csproj
++++ b/src/NzbDrone.Api.Test/Sonarr.Api.Test.csproj
+@@ -3,7 +3,6 @@
+     <TargetFrameworks>net6.0</TargetFrameworks>
+   </PropertyGroup>
+   <ItemGroup>
+-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+     <PackageReference Include="NBuilder" Version="6.1.0" />
+   </ItemGroup>
+   <ItemGroup>
+diff --git a/src/NzbDrone.Automation.Test/Sonarr.Automation.Test.csproj b/src/NzbDrone.Automation.Test/Sonarr.Automation.Test.csproj
+index 9cf8337896df7c36f33869d5f2df628524b25388..106e0695422b85a2451801c28881f505f2750769 100644
+--- a/src/NzbDrone.Automation.Test/Sonarr.Automation.Test.csproj
++++ b/src/NzbDrone.Automation.Test/Sonarr.Automation.Test.csproj
+@@ -3,7 +3,6 @@
+     <TargetFrameworks>net6.0</TargetFrameworks>
+   </PropertyGroup>
+   <ItemGroup>
+-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+     <PackageReference Include="Selenium.Support" Version="3.141.0" />
+     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="111.0.5563.6400" />
+   </ItemGroup>
+diff --git a/src/NzbDrone.Common.Test/Sonarr.Common.Test.csproj b/src/NzbDrone.Common.Test/Sonarr.Common.Test.csproj
+index 402cae2bfc393b6ac3c26d8be86f14d7a1b06862..2d4819b351b97b91a832c20f6fc577bde75aafe5 100644
+--- a/src/NzbDrone.Common.Test/Sonarr.Common.Test.csproj
++++ b/src/NzbDrone.Common.Test/Sonarr.Common.Test.csproj
+@@ -3,7 +3,6 @@
+     <TargetFrameworks>net6.0</TargetFrameworks>
+   </PropertyGroup>
+   <ItemGroup>
+-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+   </ItemGroup>
+   <ItemGroup>
+     <ProjectReference Include="..\NzbDrone.Host\Sonarr.Host.csproj" />
+diff --git a/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs b/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs
+index f71a6e2d5e7fb14d311c2936a22bc9868197a00c..bd7ee6a5b80ad98ec7b5d5220b9121753535c8fd 100644
+--- a/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs
++++ b/src/NzbDrone.Core.Test/DecisionEngineTests/DownloadDecisionMakerFixture.cs
+@@ -10,6 +10,7 @@
+ using NzbDrone.Core.IndexerSearch.Definitions;
+ using NzbDrone.Core.Parser;
+ using NzbDrone.Core.Parser.Model;
++using NzbDrone.Core.Qualities;
+ using NzbDrone.Core.Test.Framework;
+ using NzbDrone.Core.Tv;
+ using NzbDrone.Test.Common;
+@@ -347,5 +348,741 @@ public void should_return_unknown_series_rejection_if_series_title_is_an_alias_f
+             result.Should().HaveCount(1);
+             result.First().Rejections.First().Message.Should().Contain("12345");
+         }
++
++        [TestCase("[SavI0r] El Cazador de la Bruja [DVD][480p][AV1][OPUS][Dual Audio]")]
++        [TestCase("[Exiled-Destiny] El Cazador De La Bruja [Dual Audio]")]
++        [TestCase("El Cazador de la Bruja ( 480p ) [ Eng Subs ]")]
++        public void should_treat_bare_title_as_season_pack_during_anime_season_search(string releaseTitle)
++        {
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "El Cazador de la Bruja")
++                .With(s => s.TvdbId = 79099)
++                .Build();
++
++            var episodes = new List<Episode> { Builder<Episode>.CreateNew().With(e => e.SeasonNumber = 1).Build() };
++
++            var criteria = new AnimeSeasonSearchCriteria
++            {
++                Series = series,
++                SeasonNumber = 1,
++                SceneTitles = new List<string> { "El Cazador de la Bruja" },
++                Episodes = episodes
++            };
++
++            _reports = new List<ReleaseInfo> { new ReleaseInfo { Title = releaseTitle } };
++
++            var remoteEpisode = new RemoteEpisode
++            {
++                Series = series,
++                Episodes = episodes
++            };
++
++            Mocker.GetMock<IParsingService>()
++                .Setup(c => c.Map(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<SearchCriteriaBase>()))
++                .Returns(remoteEpisode);
++
++            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            _pass2.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            _pass3.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            GivenSpecifications(_pass1, _pass2, _pass3);
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Approved.Should().BeTrue();
++
++            Mocker.GetMock<IParsingService>()
++                .Verify(
++                    c => c.Map(
++                        It.Is<ParsedEpisodeInfo>(p => p.FullSeason && p.SeasonNumber == 1 && p.SeriesTitle == "El Cazador de la Bruja"),
++                        It.IsAny<int>(),
++                        It.IsAny<int>(),
++                        It.IsAny<string>(),
++                        It.IsAny<SearchCriteriaBase>()),
++                    Times.Once());
++        }
++
++        [Test]
++        public void should_treat_single_season_alias_only_bare_title_as_season_pack_during_anime_season_search()
++        {
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "Example Anime Title")
++                .With(s => s.TvdbId = 123456)
++                .Build();
++
++            var episodes = new List<Episode> { Builder<Episode>.CreateNew().With(e => e.SeasonNumber = 1).Build() };
++
++            var criteria = new AnimeSeasonSearchCriteria
++            {
++                Series = series,
++                SeasonNumber = 1,
++                SceneTitles = new List<string> { "Example Anime", "Example Anime Title" },
++                Episodes = episodes
++            };
++
++            _reports = new List<ReleaseInfo> { new ReleaseInfo { Title = "[Group] Example Anime [1080p]" } };
++
++            var remoteEpisode = new RemoteEpisode
++            {
++                Series = series,
++                Episodes = episodes
++            };
++
++            Mocker.GetMock<IParsingService>()
++                .Setup(c => c.Map(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<SearchCriteriaBase>()))
++                .Returns(remoteEpisode);
++
++            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            _pass2.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            _pass3.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            GivenSpecifications(_pass1, _pass2, _pass3);
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Approved.Should().BeTrue();
++
++            Mocker.GetMock<IParsingService>()
++                .Verify(
++                    c => c.Map(
++                        It.Is<ParsedEpisodeInfo>(p => p.FullSeason && p.SeasonNumber == 1 && p.SeriesTitle == "Example Anime Title"),
++                        It.IsAny<int>(),
++                        It.IsAny<int>(),
++                        It.IsAny<string>(),
++                        It.IsAny<SearchCriteriaBase>()),
++                    Times.Once());
++        }
++
++        [Test]
++        public void should_treat_bare_title_with_parenthesized_year_as_season_pack_during_anime_season_search()
++        {
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "Noir")
++                .With(s => s.TvdbId = 79099)
++                .Build();
++
++            var episodes = new List<Episode> { Builder<Episode>.CreateNew().With(e => e.SeasonNumber = 1).Build() };
++
++            var criteria = new AnimeSeasonSearchCriteria
++            {
++                Series = series,
++                SeasonNumber = 1,
++                SceneTitles = new List<string> { "Noir" },
++                Episodes = episodes
++            };
++
++            _reports = new List<ReleaseInfo>
++            {
++                new ReleaseInfo { Title = "[SavI0r] Noir (2001) [BD][1080p][AV1][OPUS][Multi Dual Audio]" }
++            };
++
++            var remoteEpisode = new RemoteEpisode
++            {
++                Series = series,
++                Episodes = episodes
++            };
++
++            Mocker.GetMock<IParsingService>()
++                .Setup(c => c.Map(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<SearchCriteriaBase>()))
++                .Returns(remoteEpisode);
++
++            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            GivenSpecifications(_pass1);
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Approved.Should().BeTrue();
++
++            Mocker.GetMock<IParsingService>()
++                .Verify(
++                    c => c.Map(
++                        It.Is<ParsedEpisodeInfo>(p =>
++                            p.FullSeason &&
++                            p.SeasonNumber == 1 &&
++                            p.SeriesTitle == "Noir" &&
++                            p.Quality.Quality == Quality.Bluray1080p),
++                        It.IsAny<int>(),
++                        It.IsAny<int>(),
++                        It.IsAny<string>(),
++                        It.IsAny<SearchCriteriaBase>()),
++                    Times.Once());
++        }
++
++        [Test]
++        public void should_not_treat_polluted_short_title_as_season_pack_during_anime_season_search()
++        {
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "Noir")
++                .With(s => s.TvdbId = 79099)
++                .Build();
++
++            var criteria = new AnimeSeasonSearchCriteria
++            {
++                Series = series,
++                SeasonNumber = 1,
++                SceneTitles = new List<string> { "Noir" },
++                Episodes = new List<Episode>()
++            };
++
++            _reports = new List<ReleaseInfo>
++            {
++                new ReleaseInfo { Title = "[SavI0r] Synduality: Noir [BD][1080p][AV1][OPUS][Multi Dual Audio]" }
++            };
++
++            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            GivenSpecifications(_pass1);
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Rejections.Should().Contain(r => r.Message == "Unable to parse release");
++
++            Mocker.GetMock<IParsingService>()
++                .Verify(
++                    c => c.Map(
++                        It.Is<ParsedEpisodeInfo>(p => p.FullSeason && p.SeriesTitle == "Noir"),
++                        It.IsAny<int>(),
++                        It.IsAny<int>(),
++                        It.IsAny<string>(),
++                        It.IsAny<SearchCriteriaBase>()),
++                    Times.Never());
++        }
++
++        [TestCase("[SavI0r] El Cazador de la Bruja [DVD][480p][AV1][OPUS][Dual Audio]")]
++        public void should_not_treat_bare_title_as_season_pack_outside_anime_search(string releaseTitle)
++        {
++            GivenSpecifications(_pass1, _pass2, _pass3);
++
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "El Cazador de la Bruja")
++                .Build();
++
++            _reports = new List<ReleaseInfo> { new ReleaseInfo { Title = releaseTitle } };
++
++            // Standard season search (not anime) should reject as unparseable
++            var criteria = new SeasonSearchCriteria
++            {
++                Series = series,
++                SeasonNumber = 1,
++                SceneTitles = new List<string> { "El Cazador de la Bruja" },
++                Episodes = new List<Episode>()
++            };
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Rejections.Should().Contain(r => r.Message == "Unable to parse release");
++        }
++
++        [TestCase("[DVD_ISO] El Cazador de la Bruja (US, FUNi)")]
++        [TestCase("[Starlight] El Cazador de la Bruja (h264)")]
++        [TestCase("El Cazador De La Bruja(RAW)")]
++        public void should_not_treat_bare_title_with_unsafe_metadata_as_season_pack(string releaseTitle)
++        {
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "El Cazador de la Bruja")
++                .With(s => s.TvdbId = 79099)
++                .Build();
++
++            var criteria = new AnimeSeasonSearchCriteria
++            {
++                Series = series,
++                SeasonNumber = 1,
++                SceneTitles = new List<string> { "El Cazador de la Bruja" },
++                Episodes = new List<Episode>()
++            };
++
++            _reports = new List<ReleaseInfo> { new ReleaseInfo { Title = releaseTitle } };
++
++            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            GivenSpecifications(_pass1);
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Rejections.Should().Contain(r => r.Message == "Unable to parse release");
++        }
++
++        [TestCase("[SavI0r] El Cazador de la Bruja OVA [DVD][480p]")]
++        [TestCase("[SavI0r] El Cazador de la Bruja Movie [DVD][480p]")]
++        [TestCase("[SavI0r] El Cazador de la Bruja Special [DVD][480p]")]
++        public void should_not_treat_bare_title_with_special_keywords_as_season_pack(string releaseTitle)
++        {
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "El Cazador de la Bruja")
++                .With(s => s.TvdbId = 79099)
++                .Build();
++
++            var criteria = new AnimeSeasonSearchCriteria
++            {
++                Series = series,
++                SeasonNumber = 1,
++                SceneTitles = new List<string> { "El Cazador de la Bruja" },
++                Episodes = new List<Episode>()
++            };
++
++            _reports = new List<ReleaseInfo> { new ReleaseInfo { Title = releaseTitle } };
++
++            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            GivenSpecifications(_pass1);
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Rejections.Should().Contain(r => r.Message == "Unable to parse release");
++        }
++
++        [TestCase("[SavI0r] El Cazador de la Bruja [DVD][480p][AV1][OPUS][Dual Audio]")]
++        public void should_not_treat_bare_title_as_season_pack_for_season_0(string releaseTitle)
++        {
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "El Cazador de la Bruja")
++                .With(s => s.TvdbId = 79099)
++                .Build();
++
++            var criteria = new AnimeSeasonSearchCriteria
++            {
++                Series = series,
++                SeasonNumber = 0,
++                SceneTitles = new List<string> { "El Cazador de la Bruja" },
++                Episodes = new List<Episode>()
++            };
++
++            _reports = new List<ReleaseInfo> { new ReleaseInfo { Title = releaseTitle } };
++
++            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            GivenSpecifications(_pass1);
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Rejections.Should().Contain(r => r.Message == "Unable to parse release");
++        }
++
++        [TestCase("[HcLs] Hai to Gensou no Grimgar + OVA [1080p]")]
++        [TestCase("[Group] Hai to Gensou no Grimgar OVA [720p]")]
++        [TestCase("[Group] Hai to Gensou no Grimgar Special [BD]")]
++        public void should_treat_ova_release_as_special_during_special_search(string releaseTitle)
++        {
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "Hai to Gensou no Grimgar")
++                .With(s => s.TvdbId = 306141)
++                .With(s => s.SeriesType = SeriesTypes.Anime)
++                .Build();
++
++            var episode = Builder<Episode>.CreateNew()
++                .With(e => e.SeasonNumber = 0)
++                .With(e => e.EpisodeNumber = 1)
++                .Build();
++
++            var criteria = new SpecialEpisodeSearchCriteria
++            {
++                Series = series,
++                SceneTitles = new List<string> { "Hai to Gensou no Grimgar" },
++                Episodes = new List<Episode> { episode },
++                EpisodeQueryTitles = new[] { "Hai to Gensou no Grimgar OVA" }
++            };
++
++            _reports = new List<ReleaseInfo> { new ReleaseInfo { Title = releaseTitle } };
++
++            var remoteEpisode = new RemoteEpisode
++            {
++                Series = series,
++                Episodes = new List<Episode> { episode }
++            };
++
++            Mocker.GetMock<IParsingService>()
++                .Setup(c => c.Map(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<SearchCriteriaBase>()))
++                .Returns(remoteEpisode);
++
++            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            GivenSpecifications(_pass1);
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Approved.Should().BeTrue();
++
++            Mocker.GetMock<IParsingService>()
++                .Verify(
++                    c => c.Map(
++                        It.Is<ParsedEpisodeInfo>(p => p.SeasonNumber == 0 && p.EpisodeNumbers.Contains(1)),
++                        It.IsAny<int>(),
++                        It.IsAny<int>(),
++                        It.IsAny<string>(),
++                        It.IsAny<SearchCriteriaBase>()),
++                    Times.Once());
++        }
++
++        [TestCase("[Group] Hai to Gensou no Grimgar Extras [BD]")]
++        [TestCase("[Group] Hai to Gensou no Grimgar NCOP [BD]")]
++        [TestCase("[Group] Hai to Gensou no Grimgar NCED [BD]")]
++        [TestCase("[Group] Hai to Gensou no Grimgar Menu [BD]")]
++        [TestCase("[Group] Hai to Gensou no Grimgar Bonus [BD]")]
++        public void should_not_treat_non_episode_markers_as_special(string releaseTitle)
++        {
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "Hai to Gensou no Grimgar")
++                .With(s => s.TvdbId = 306141)
++                .With(s => s.SeriesType = SeriesTypes.Anime)
++                .Build();
++
++            var episode = Builder<Episode>.CreateNew()
++                .With(e => e.SeasonNumber = 0)
++                .With(e => e.EpisodeNumber = 1)
++                .Build();
++
++            var criteria = new SpecialEpisodeSearchCriteria
++            {
++                Series = series,
++                SceneTitles = new List<string> { "Hai to Gensou no Grimgar" },
++                Episodes = new List<Episode> { episode },
++                EpisodeQueryTitles = new[] { "Hai to Gensou no Grimgar OVA" }
++            };
++
++            _reports = new List<ReleaseInfo> { new ReleaseInfo { Title = releaseTitle } };
++
++            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            GivenSpecifications(_pass1);
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Rejections.Should().Contain(r => r.Message == "Unable to parse release");
++        }
++
++        [Test]
++        public void should_not_use_special_fallback_for_multi_special_search()
++        {
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "Hai to Gensou no Grimgar")
++                .With(s => s.TvdbId = 306141)
++                .With(s => s.SeriesType = SeriesTypes.Anime)
++                .Build();
++
++            var episodes = new List<Episode>
++            {
++                Builder<Episode>.CreateNew().With(e => e.SeasonNumber = 0).With(e => e.EpisodeNumber = 1).Build(),
++                Builder<Episode>.CreateNew().With(e => e.SeasonNumber = 0).With(e => e.EpisodeNumber = 2).Build()
++            };
++
++            var criteria = new SpecialEpisodeSearchCriteria
++            {
++                Series = series,
++                SceneTitles = new List<string> { "Hai to Gensou no Grimgar" },
++                Episodes = episodes,
++                EpisodeQueryTitles = new[] { "Hai to Gensou no Grimgar OVA" }
++            };
++
++            _reports = new List<ReleaseInfo> { new ReleaseInfo { Title = "[Group] Hai to Gensou no Grimgar OVA [BD]" } };
++
++            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            GivenSpecifications(_pass1);
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Rejections.Should().Contain(r => r.Message == "Unable to parse release");
++        }
++
++        [Test]
++        public void should_not_use_special_fallback_for_non_anime_series()
++        {
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "Some Show")
++                .With(s => s.TvdbId = 12345)
++                .With(s => s.SeriesType = SeriesTypes.Standard)
++                .Build();
++
++            var episode = Builder<Episode>.CreateNew()
++                .With(e => e.SeasonNumber = 0)
++                .With(e => e.EpisodeNumber = 1)
++                .Build();
++
++            var criteria = new SpecialEpisodeSearchCriteria
++            {
++                Series = series,
++                SceneTitles = new List<string> { "Some Show" },
++                Episodes = new List<Episode> { episode },
++                EpisodeQueryTitles = new[] { "Some Show Special" }
++            };
++
++            _reports = new List<ReleaseInfo> { new ReleaseInfo { Title = "[Group] Some Show Special [BD]" } };
++
++            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            GivenSpecifications(_pass1);
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Rejections.Should().Contain(r => r.Message == "Unable to parse release");
++        }
++
++        [TestCase("[HcLs] Hai to Gensou no Grimgar(Grimgar of Fantasy and Ash) + OVA (Dual Audio) [BD 1080p x265 10bit]_Rokey")]
++        [TestCase("[HcLs] Hai to Gensou no Grimgar (Grimgar of Fantasy and Ash) + OVA (Dual Audio) [BD 1080p x265 10bit]_Rokey")]
++        [TestCase("[SubGroup] Hai to Gensou no Grimgar(Alt Title) + OVA [720p]")]
++        [TestCase("[Group] Hai to Gensou no Grimgar(Alt Title) OVA [BD]-Tag")]
++        public void should_match_bare_title_with_inline_alt_name_and_ova(string releaseTitle)
++        {
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "Hai to Gensou no Grimgar")
++                .With(s => s.TvdbId = 306141)
++                .With(s => s.SeriesType = SeriesTypes.Anime)
++                .Build();
++
++            var episode = Builder<Episode>.CreateNew()
++                .With(e => e.SeasonNumber = 0)
++                .With(e => e.EpisodeNumber = 1)
++                .Build();
++
++            var criteria = new SpecialEpisodeSearchCriteria
++            {
++                Series = series,
++                SceneTitles = new List<string> { "Hai to Gensou no Grimgar" },
++                Episodes = new List<Episode> { episode },
++                EpisodeQueryTitles = new[] { "Hai to Gensou no Grimgar OVA" }
++            };
++
++            _reports = new List<ReleaseInfo> { new ReleaseInfo { Title = releaseTitle } };
++
++            var remoteEpisode = new RemoteEpisode
++            {
++                Series = series,
++                Episodes = new List<Episode> { episode }
++            };
++
++            Mocker.GetMock<IParsingService>()
++                .Setup(c => c.Map(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<SearchCriteriaBase>()))
++                .Returns(remoteEpisode);
++
++            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            GivenSpecifications(_pass1);
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Approved.Should().BeTrue();
++
++            Mocker.GetMock<IParsingService>()
++                .Verify(
++                    c => c.Map(
++                        It.Is<ParsedEpisodeInfo>(p => p.SeasonNumber == 0 && p.EpisodeNumbers.Contains(1)),
++                        It.IsAny<int>(),
++                        It.IsAny<int>(),
++                        It.IsAny<string>(),
++                        It.IsAny<SearchCriteriaBase>()),
++                    Times.Once());
++        }
++
++        [Test]
++        public void should_not_accept_bare_title_via_season_pack_fallback_for_season_0()
++        {
++            // A title that would succeed via TryBuildAnimeSeasonPackInfo for Season 1
++            // must be rejected for Season 0 — the guard returns null immediately.
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "Hai to Gensou no Grimgar")
++                .With(s => s.TvdbId = 306141)
++                .Build();
++
++            var episodes = new List<Episode> { Builder<Episode>.CreateNew().With(e => e.SeasonNumber = 0).Build() };
++
++            var criteria = new AnimeSeasonSearchCriteria
++            {
++                Series = series,
++                SeasonNumber = 0,
++                SceneTitles = new List<string> { "Hai to Gensou no Grimgar" },
++                Episodes = episodes
++            };
++
++            _reports = new List<ReleaseInfo>
++            {
++                new ReleaseInfo { Title = "[F-D] Hai to Gensou no Grimgar [480P][Dual-Audio]" }
++            };
++
++            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            GivenSpecifications(_pass1);
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Rejections.Should().Contain(r => r.Message == "Unable to parse release");
++
++            // Verify Map was never called — the fallback should not have produced a synthetic ParsedEpisodeInfo
++            Mocker.GetMock<IParsingService>()
++                .Verify(
++                    c => c.Map(
++                        It.Is<ParsedEpisodeInfo>(p => p.FullSeason && p.SeasonNumber == 0),
++                        It.IsAny<int>(),
++                        It.IsAny<int>(),
++                        It.IsAny<string>(),
++                        It.IsAny<SearchCriteriaBase>()),
++                    Times.Never());
++        }
++
++        [TestCase("[Group] Sword Art Online S01E01 [720p]")]
++        public void should_not_use_bare_title_fallback_when_parser_resolves_normally(string releaseTitle)
++        {
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "Sword Art Online")
++                .With(s => s.TvdbId = 259640)
++                .Build();
++
++            var episodes = new List<Episode> { Builder<Episode>.CreateNew().With(e => e.SeasonNumber = 1).Build() };
++
++            var criteria = new AnimeSeasonSearchCriteria
++            {
++                Series = series,
++                SeasonNumber = 1,
++                SceneTitles = new List<string> { "Sword Art Online" },
++                Episodes = episodes
++            };
++
++            _reports = new List<ReleaseInfo> { new ReleaseInfo { Title = releaseTitle } };
++
++            var remoteEpisode = new RemoteEpisode
++            {
++                Series = series,
++                Episodes = episodes
++            };
++
++            Mocker.GetMock<IParsingService>()
++                .Setup(c => c.Map(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<SearchCriteriaBase>()))
++                .Returns(remoteEpisode);
++
++            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            GivenSpecifications(_pass1);
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Approved.Should().BeTrue();
++
++            // Normal parser should handle this — Map should be called with the parser's output, not a synthetic pack
++            Mocker.GetMock<IParsingService>()
++                .Verify(
++                    c => c.Map(
++                        It.Is<ParsedEpisodeInfo>(p => !p.FullSeason),
++                        It.IsAny<int>(),
++                        It.IsAny<int>(),
++                        It.IsAny<string>(),
++                        It.IsAny<SearchCriteriaBase>()),
++                    Times.Once());
++        }
++
++        [TestCase("[Group] Sword Art Online 01-25 [1080p]")]
++        public void should_not_use_bare_title_fallback_for_absolute_range_release(string releaseTitle)
++        {
++            // Absolute range releases should be parsed normally, not by the bare-title fallback
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "Sword Art Online")
++                .With(s => s.TvdbId = 259640)
++                .Build();
++
++            var episodes = new List<Episode> { Builder<Episode>.CreateNew().With(e => e.SeasonNumber = 1).Build() };
++
++            var criteria = new AnimeSeasonSearchCriteria
++            {
++                Series = series,
++                SeasonNumber = 1,
++                SceneTitles = new List<string> { "Sword Art Online" },
++                Episodes = episodes
++            };
++
++            _reports = new List<ReleaseInfo> { new ReleaseInfo { Title = releaseTitle } };
++
++            var remoteEpisode = new RemoteEpisode
++            {
++                Series = series,
++                Episodes = episodes
++            };
++
++            Mocker.GetMock<IParsingService>()
++                .Setup(c => c.Map(It.IsAny<ParsedEpisodeInfo>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<SearchCriteriaBase>()))
++                .Returns(remoteEpisode);
++
++            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            GivenSpecifications(_pass1);
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Approved.Should().BeTrue();
++
++            // Should use parser's output, not a synthetic full season pack
++            Mocker.GetMock<IParsingService>()
++                .Verify(
++                    c => c.Map(
++                        It.Is<ParsedEpisodeInfo>(p => p.FullSeason),
++                        It.IsAny<int>(),
++                        It.IsAny<int>(),
++                        It.IsAny<string>(),
++                        It.IsAny<SearchCriteriaBase>()),
++                    Times.Never());
++        }
++
++        [Test]
++        public void should_not_treat_bare_title_with_mismatched_tvdbid_as_season_pack()
++        {
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "El Cazador de la Bruja")
++                .With(s => s.TvdbId = 79099)
++                .Build();
++
++            var criteria = new AnimeSeasonSearchCriteria
++            {
++                Series = series,
++                SeasonNumber = 1,
++                SceneTitles = new List<string> { "El Cazador de la Bruja" },
++                Episodes = new List<Episode>()
++            };
++
++            // Report has a different TvdbId — should be rejected
++            _reports = new List<ReleaseInfo>
++            {
++                new ReleaseInfo { Title = "[Group] El Cazador de la Bruja [DVD]", TvdbId = 99999 }
++            };
++
++            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            GivenSpecifications(_pass1);
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Rejections.Should().Contain(r => r.Message == "Unable to parse release");
++        }
++
++        [Test]
++        public void should_not_use_special_fallback_for_non_season0_episode()
++        {
++            // Ensure the OVA/Special fallback only fires for Season 0 episodes
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Title = "Test Anime")
++                .With(s => s.SeriesType = SeriesTypes.Anime)
++                .Build();
++
++            var episode = Builder<Episode>.CreateNew()
++                .With(e => e.SeasonNumber = 1)
++                .With(e => e.EpisodeNumber = 1)
++                .Build();
++
++            var criteria = new SpecialEpisodeSearchCriteria
++            {
++                Series = series,
++                SceneTitles = new List<string> { "Test Anime" },
++                Episodes = new List<Episode> { episode },
++                EpisodeQueryTitles = new[] { "Test Anime OVA" }
++            };
++
++            _reports = new List<ReleaseInfo> { new ReleaseInfo { Title = "[Group] Test Anime OVA [BD]" } };
++
++            _pass1.Setup(c => c.IsSatisfiedBy(It.IsAny<RemoteEpisode>(), It.IsAny<SearchCriteriaBase>())).Returns(DownloadSpecDecision.Accept);
++            GivenSpecifications(_pass1);
++
++            var result = Subject.GetSearchDecision(_reports, criteria).ToList();
++
++            result.Should().HaveCount(1);
++            result.First().Rejections.Should().Contain(r => r.Message == "Unable to parse release");
++        }
+     }
+ }
+diff --git a/src/NzbDrone.Core.Test/DecisionEngineTests/MultiSeasonSpecificationFixture.cs b/src/NzbDrone.Core.Test/DecisionEngineTests/MultiSeasonSpecificationFixture.cs
+index 8a853e387ca007e642586e8af493389387d1694d..5a797e100f7ade68efdaf121771e6525f9d962bb 100644
+--- a/src/NzbDrone.Core.Test/DecisionEngineTests/MultiSeasonSpecificationFixture.cs
++++ b/src/NzbDrone.Core.Test/DecisionEngineTests/MultiSeasonSpecificationFixture.cs
+@@ -6,6 +6,7 @@
+ using Moq;
+ using NUnit.Framework;
+ using NzbDrone.Core.DecisionEngine.Specifications;
++using NzbDrone.Core.IndexerSearch.Definitions;
+ using NzbDrone.Core.Parser.Model;
+ using NzbDrone.Core.Test.Framework;
+ using NzbDrone.Core.Tv;
+@@ -20,13 +21,18 @@ public class MultiSeasonSpecificationFixture : CoreTest<MultiSeasonSpecification
+         [SetUp]
+         public void Setup()
+         {
+-            var series = Builder<Series>.CreateNew().With(s => s.Id = 1234).Build();
++            var series = Builder<Series>.CreateNew()
++                .With(s => s.Id = 1234)
++                .With(s => s.SeriesType = SeriesTypes.Standard)
++                .Build();
++
+             _remoteEpisode = new RemoteEpisode
+             {
+                 ParsedEpisodeInfo = new ParsedEpisodeInfo
+                 {
+                     FullSeason = true,
+-                    IsMultiSeason = true
++                    IsMultiSeason = true,
++                    SeasonNumbers = new[] { 1, 2, 3, 4 }
+                 },
+                 Episodes = Builder<Episode>.CreateListOfSize(3)
+                                            .All()
+@@ -56,5 +62,45 @@ public void should_return_false_if_is_a_multi_season_release()
+         {
+             Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
+         }
++
++        [Test]
++        public void should_return_false_for_non_anime_multi_season_with_anime_search()
++        {
++            var searchCriteria = new AnimeSeasonSearchCriteria { SeasonNumber = 1 };
++            Subject.IsSatisfiedBy(_remoteEpisode, searchCriteria).Accepted.Should().BeFalse();
++        }
++
++        [Test]
++        public void should_return_true_for_anime_multi_season_with_anime_search()
++        {
++            _remoteEpisode.Series.SeriesType = SeriesTypes.Anime;
++            var searchCriteria = new AnimeSeasonSearchCriteria { SeasonNumber = 1 };
++            Subject.IsSatisfiedBy(_remoteEpisode, searchCriteria).Accepted.Should().BeTrue();
++        }
++
++        [Test]
++        public void should_return_false_for_anime_multi_season_without_anime_search()
++        {
++            _remoteEpisode.Series.SeriesType = SeriesTypes.Anime;
++            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeFalse();
++        }
++
++        [Test]
++        public void should_reject_anime_multi_season_when_searched_season_is_not_covered()
++        {
++            _remoteEpisode.Series.SeriesType = SeriesTypes.Anime;
++            _remoteEpisode.ParsedEpisodeInfo.SeasonNumbers = new[] { 1, 2, 3, 4 };
++            var searchCriteria = new AnimeSeasonSearchCriteria { SeasonNumber = 5 };
++            Subject.IsSatisfiedBy(_remoteEpisode, searchCriteria).Accepted.Should().BeFalse();
++        }
++
++        [Test]
++        public void should_accept_anime_multi_season_when_searched_season_is_covered()
++        {
++            _remoteEpisode.Series.SeriesType = SeriesTypes.Anime;
++            _remoteEpisode.ParsedEpisodeInfo.SeasonNumbers = new[] { 1, 2, 3, 4 };
++            var searchCriteria = new AnimeSeasonSearchCriteria { SeasonNumber = 3 };
++            Subject.IsSatisfiedBy(_remoteEpisode, searchCriteria).Accepted.Should().BeTrue();
++        }
+     }
+ }
+diff --git a/src/NzbDrone.Core.Test/DecisionEngineTests/Search/SeasonMatchSpecificationFixture.cs b/src/NzbDrone.Core.Test/DecisionEngineTests/Search/SeasonMatchSpecificationFixture.cs
+new file mode 100644
+index 0000000000000000000000000000000000000000..c5250373e682d7a4abe9c41b00f64eaba0aa48aa
+--- /dev/null
++++ b/src/NzbDrone.Core.Test/DecisionEngineTests/Search/SeasonMatchSpecificationFixture.cs
+@@ -0,0 +1,56 @@
++using FizzWare.NBuilder;
++using FluentAssertions;
++using NUnit.Framework;
++using NzbDrone.Core.DecisionEngine.Specifications.Search;
++using NzbDrone.Core.IndexerSearch.Definitions;
++using NzbDrone.Core.Parser.Model;
++using NzbDrone.Core.Tv;
++using NzbDrone.Test.Common;
++
++namespace NzbDrone.Core.Test.DecisionEngineTests.Search
++{
++    [TestFixture]
++    public class SeasonMatchSpecificationFixture : TestBase<SeasonMatchSpecification>
++    {
++        private RemoteEpisode _remoteEpisode;
++
++        [SetUp]
++        public void Setup()
++        {
++            var series = Builder<Series>.CreateNew()
++                .Build();
++
++            _remoteEpisode = new RemoteEpisode
++            {
++                Series = series,
++                ParsedEpisodeInfo = new ParsedEpisodeInfo
++                {
++                    SeasonNumber = 1,
++                    FullSeason = true
++                }
++            };
++        }
++
++        [Test]
++        public void should_accept_when_no_search_criteria()
++        {
++            Subject.IsSatisfiedBy(_remoteEpisode, null).Accepted.Should().BeTrue();
++        }
++
++        [Test]
++        public void should_reject_standard_season_mismatch()
++        {
++            var criteria = new SeasonSearchCriteria { SeasonNumber = 3 };
++
++            Subject.IsSatisfiedBy(_remoteEpisode, criteria).Accepted.Should().BeFalse();
++        }
++
++        [Test]
++        public void should_accept_standard_season_match()
++        {
++            var criteria = new SeasonSearchCriteria { SeasonNumber = 1 };
++
++            Subject.IsSatisfiedBy(_remoteEpisode, criteria).Accepted.Should().BeTrue();
++        }
++    }
++}
+diff --git a/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ProcessFixture.cs b/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ProcessFixture.cs
+index 0eac8489374b2edaf74b7e8826ff15409c81f169..048d74f63931d39e0ac82f186bf94cfa49b4639e 100644
+--- a/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ProcessFixture.cs
++++ b/src/NzbDrone.Core.Test/Download/CompletedDownloadServiceTests/ProcessFixture.cs
+@@ -179,6 +179,39 @@ public void should_not_process_when_there_is_a_title_mismatch()
+             AssertNotReadyToImport();
+         }
+ 
++        [Test]
++        public void should_process_badly_named_completed_download_when_grab_history_identifies_series()
++        {
++            _trackedDownload.DownloadItem.DownloadId = "grimgar-pack";
++            _trackedDownload.DownloadItem.Title = "[Datte13] Grimgar of Fantasy and Ash [BD 1080p Hi10] [Dual-Audio FLAC]";
++
++            var grabbedHistory = new EpisodeHistory
++            {
++                DownloadId = "grimgar-pack",
++                SourceTitle = "[Datte13] Grimgar of Fantasy and Ash [BD 1080p Hi10] [Dual-Audio FLAC]",
++                SeriesId = 44,
++                EventType = EpisodeHistoryEventType.Grabbed
++            };
++            grabbedHistory.Data.Add(EpisodeHistory.SERIES_MATCH_TYPE, SeriesMatchType.Alias.ToString());
++            grabbedHistory.Data.Add(EpisodeHistory.RELEASE_SOURCE, ReleaseSourceType.UserInvokedSearch.ToString());
++
++            Mocker.GetMock<IHistoryService>()
++                  .Setup(s => s.FindByDownloadId("grimgar-pack"))
++                  .Returns(new List<EpisodeHistory> { grabbedHistory });
++
++            Mocker.GetMock<IParsingService>()
++                  .Setup(s => s.GetSeries(It.IsAny<string>()))
++                  .Returns((Series)null);
++
++            Mocker.GetMock<ISeriesService>()
++                  .Setup(s => s.GetSeries(44))
++                  .Returns(_trackedDownload.RemoteEpisode.Series);
++
++            Subject.Check(_trackedDownload);
++
++            AssertReadyToImport();
++        }
++
+         private void AssertNotReadyToImport()
+         {
+             _trackedDownload.State.Should().NotBe(TrackedDownloadState.ImportPending);
+diff --git a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+index 0c07b6386e59fd1349dbdece98b97d1214a7e619..d780dbfc8263d26bd9ccac2f212e3505dd910375 100644
+--- a/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
++++ b/src/NzbDrone.Core.Test/Download/TrackedDownloads/TrackedDownloadServiceFixture.cs
+@@ -31,7 +31,8 @@ private void GivenDownloadHistory()
+                      DownloadId = "35238",
+                      SourceTitle = "TV Series S01",
+                      SeriesId = 5,
+-                     EpisodeId = 4
++                     EpisodeId = 4,
++                     EventType = EpisodeHistoryEventType.Grabbed
+                 }
+                 });
+         }
+@@ -86,6 +87,189 @@ public void should_track_downloads_using_the_source_title_if_it_cannot_be_found_
+             trackedDownload.RemoteEpisode.MappedSeasonNumber.Should().Be(1);
+         }
+ 
++        [Test]
++        public void should_use_grabbed_history_instead_of_newer_non_grab_history_when_tracking_download()
++        {
++            var grabbedHistory = new EpisodeHistory
++            {
++                DownloadId = "35238",
++                SourceTitle = "TV Series S01",
++                SeriesId = 5,
++                EpisodeId = 4,
++                EventType = EpisodeHistoryEventType.Grabbed
++            };
++
++            var importedHistory = new EpisodeHistory
++            {
++                DownloadId = "35238",
++                SourceTitle = @"C:\DropFolder\TV Series\TV Series - S01E01.mkv",
++                SeriesId = 99,
++                EpisodeId = 999,
++                EventType = EpisodeHistoryEventType.DownloadFolderImported
++            };
++
++            Mocker.GetMock<IHistoryService>()
++                .Setup(s => s.FindByDownloadId("35238"))
++                .Returns(new List<EpisodeHistory> { importedHistory, grabbedHistory });
++
++            var remoteEpisode = new RemoteEpisode
++            {
++                Series = new Series { Id = 5 },
++                Episodes = new List<Episode> { new Episode { Id = 4 } },
++                ParsedEpisodeInfo = new ParsedEpisodeInfo
++                {
++                    SeriesTitle = "TV Series",
++                    SeasonNumber = 1
++                },
++                MappedSeasonNumber = 1
++            };
++
++            Mocker.GetMock<IParsingService>()
++                .Setup(s => s.Map(It.Is<ParsedEpisodeInfo>(i => i.SeasonNumber == 1 && i.SeriesTitle == "TV Series"),
++                    5,
++                    It.Is<IEnumerable<int>>(episodes => episodes.SequenceEqual(new[] { 4 }))))
++                .Returns(remoteEpisode);
++
++            var client = new DownloadClientDefinition
++            {
++                Id = 1,
++                Protocol = DownloadProtocol.Torrent
++            };
++
++            var item = new DownloadClientItem
++            {
++                Title = "The torrent release folder",
++                DownloadId = "35238",
++                DownloadClientInfo = new DownloadClientItemClientInfo
++                {
++                    Protocol = client.Protocol,
++                    Id = client.Id,
++                    Name = client.Name
++                }
++            };
++
++            var trackedDownload = Subject.TrackDownload(client, item);
++
++            trackedDownload.RemoteEpisode.Should().NotBeNull();
++            trackedDownload.RemoteEpisode.Series.Id.Should().Be(5);
++            trackedDownload.RemoteEpisode.Episodes.Select(e => e.Id).Should().Equal(4);
++        }
++
++        [Test]
++        public void should_build_remote_episode_from_grabbed_history_when_titles_are_unparseable()
++        {
++            var grabbedTitle = "[Datte13] Grimgar of Fantasy and Ash [BD 1080p Hi10] [Dual-Audio FLAC]";
++            var grabbedHistory1 = new EpisodeHistory
++            {
++                DownloadId = "grimgar-pack",
++                SourceTitle = grabbedTitle,
++                SeriesId = 44,
++                EpisodeId = 1361,
++                EventType = EpisodeHistoryEventType.Grabbed
++            };
++            var grabbedHistory2 = new EpisodeHistory
++            {
++                DownloadId = "grimgar-pack",
++                SourceTitle = grabbedTitle,
++                SeriesId = 44,
++                EpisodeId = 1362,
++                EventType = EpisodeHistoryEventType.Grabbed
++            };
++            var importedHistory = new EpisodeHistory
++            {
++                DownloadId = "grimgar-pack",
++                SourceTitle = @"/data/media/anime/Grimgar, Ashes and Illusions (2016)/Grimgar, Ashes and Illusions (2016) - S01E01.mkv",
++                SeriesId = 44,
++                EpisodeId = 1361,
++                EventType = EpisodeHistoryEventType.DownloadFolderImported
++            };
++
++            Mocker.GetMock<IHistoryService>()
++                .Setup(s => s.FindByDownloadId("grimgar-pack"))
++                .Returns(new List<EpisodeHistory> { importedHistory, grabbedHistory2, grabbedHistory1 });
++
++            var remoteEpisode = new RemoteEpisode
++            {
++                Series = new Series { Id = 44 },
++                Episodes = new List<Episode> { new Episode { Id = 1361 }, new Episode { Id = 1362 } },
++                ParsedEpisodeInfo = new ParsedEpisodeInfo
++                {
++                    ReleaseTitle = grabbedTitle
++                }
++            };
++
++            Mocker.GetMock<IParsingService>()
++                .Setup(s => s.Map(It.Is<ParsedEpisodeInfo>(i => i.ReleaseTitle == grabbedTitle),
++                    44,
++                    It.Is<IEnumerable<int>>(episodes => episodes.SequenceEqual(new[] { 1362, 1361 }) || episodes.SequenceEqual(new[] { 1361, 1362 }))))
++                .Returns(remoteEpisode);
++
++            var client = new DownloadClientDefinition
++            {
++                Id = 1,
++                Protocol = DownloadProtocol.Torrent
++            };
++
++            var item = new DownloadClientItem
++            {
++                Title = "The torrent release folder",
++                DownloadId = "grimgar-pack",
++                DownloadClientInfo = new DownloadClientItemClientInfo
++                {
++                    Protocol = client.Protocol,
++                    Id = client.Id,
++                    Name = client.Name
++                }
++            };
++
++            var trackedDownload = Subject.TrackDownload(client, item);
++
++            trackedDownload.RemoteEpisode.Should().NotBeNull();
++            trackedDownload.RemoteEpisode.Series.Id.Should().Be(44);
++            trackedDownload.RemoteEpisode.Episodes.Select(e => e.Id).Should().Equal(1361, 1362);
++            trackedDownload.RemoteEpisode.ParsedEpisodeInfo.ReleaseTitle.Should().Be(grabbedTitle);
++        }
++
++        [Test]
++        public void should_leave_download_unresolved_when_no_grabbed_history_exists()
++        {
++            Mocker.GetMock<IHistoryService>()
++                .Setup(s => s.FindByDownloadId("35238"))
++                .Returns(new List<EpisodeHistory>
++                {
++                    new EpisodeHistory
++                    {
++                        DownloadId = "35238",
++                        SourceTitle = @"C:\DropFolder\TV Series\TV Series - S01E01.mkv",
++                        SeriesId = 5,
++                        EpisodeId = 4,
++                        EventType = EpisodeHistoryEventType.DownloadFolderImported
++                    }
++                });
++
++            var client = new DownloadClientDefinition
++            {
++                Id = 1,
++                Protocol = DownloadProtocol.Torrent
++            };
++
++            var item = new DownloadClientItem
++            {
++                Title = "The torrent release folder",
++                DownloadId = "35238",
++                DownloadClientInfo = new DownloadClientItemClientInfo
++                {
++                    Protocol = client.Protocol,
++                    Id = client.Id,
++                    Name = client.Name
++                }
++            };
++
++            var trackedDownload = Subject.TrackDownload(client, item);
++
++            trackedDownload.RemoteEpisode.Should().BeNull();
++        }
++
+         [Test]
+         public void should_set_indexer()
+         {
+@@ -185,7 +369,8 @@ public void should_parse_as_special_when_source_title_parsing_fails()
+                      DownloadId = "35238",
+                      SourceTitle = "TV Series Special",
+                      SeriesId = 5,
+-                     EpisodeId = 4
++                     EpisodeId = 4,
++                     EventType = EpisodeHistoryEventType.Grabbed
+                 }
+                 });
+ 
+diff --git a/src/NzbDrone.Core.Test/Framework/DbTest.cs b/src/NzbDrone.Core.Test/Framework/DbTest.cs
+index fba791b152da41eebf9a4fee0b841acf9be5f5fd..e64779458cc5f50d38c2d3439ffcba8ae756c783 100644
+--- a/src/NzbDrone.Core.Test/Framework/DbTest.cs
++++ b/src/NzbDrone.Core.Test/Framework/DbTest.cs
+@@ -180,7 +180,7 @@ protected void SetupContainer()
+             // Set up remaining container services
+             Mocker.SetConstant(Options.Create(postgresOptions));
+             Mocker.SetConstant<IConfigFileProvider>(Mocker.Resolve<ConfigFileProvider>());
+-            Mocker.SetConstant<IConnectionStringFactory>(Mocker.Resolve<ConnectionStringFactory>());
++            Mocker.SetConstant<IConnectionStringFactory>(new TestConnectionStringFactory(Mocker.Resolve<ConnectionStringFactory>()));
+             Mocker.SetConstant<IMigrationController>(Mocker.Resolve<MigrationController>());
+ 
+             SqlBuilderExtensions.LogSql = true;
+@@ -213,5 +213,39 @@ public void TearDown()
+                 DropPostgresDb();
+             }
+         }
++
++        private class TestConnectionStringFactory : IConnectionStringFactory
++        {
++            public TestConnectionStringFactory(IConnectionStringFactory inner)
++            {
++                MainDbConnection = DisablePooling(inner.MainDbConnection);
++                LogDbConnection = DisablePooling(inner.LogDbConnection);
++            }
++
++            public DatabaseConnectionInfo MainDbConnection { get; }
++            public DatabaseConnectionInfo LogDbConnection { get; }
++
++            public string GetDatabasePath(string connectionString)
++            {
++                var connectionBuilder = new SQLiteConnectionStringBuilder(connectionString);
++
++                return connectionBuilder.DataSource;
++            }
++
++            private static DatabaseConnectionInfo DisablePooling(DatabaseConnectionInfo connectionInfo)
++            {
++                if (connectionInfo.DatabaseType != DatabaseType.SQLite)
++                {
++                    return connectionInfo;
++                }
++
++                var connectionBuilder = new SQLiteConnectionStringBuilder(connectionInfo.ConnectionString)
++                {
++                    Pooling = false
++                };
++
++                return new DatabaseConnectionInfo(connectionInfo.DatabaseType, connectionBuilder.ConnectionString);
++            }
++        }
+     }
+ }
+diff --git a/src/NzbDrone.Core.Test/Framework/MigrationTest.cs b/src/NzbDrone.Core.Test/Framework/MigrationTest.cs
+index 9ac581a83eae6b21e585f100db9625ba1d65c720..d6fb692f72b5a4967616a6d7130abb6cebc1e97f 100644
+--- a/src/NzbDrone.Core.Test/Framework/MigrationTest.cs
++++ b/src/NzbDrone.Core.Test/Framework/MigrationTest.cs
+@@ -2,7 +2,7 @@
+ using System.Data;
+ using FluentMigrator;
+ using Microsoft.Extensions.Logging;
+-using NLog.Extensions.Logging;
++using Microsoft.Extensions.Logging.Abstractions;
+ using NUnit.Framework;
+ using NzbDrone.Core.Datastore.Migration.Framework;
+ 
+@@ -33,7 +33,7 @@ protected virtual IDbConnection WithDapperMigrationTestDb(Action<TMigration> bef
+ 
+         protected override void SetupLogging()
+         {
+-            Mocker.SetConstant<ILoggerProvider>(Mocker.Resolve<NLogLoggerProvider>());
++            Mocker.SetConstant<ILoggerProvider>(NullLoggerProvider.Instance);
+         }
+ 
+         private ITestDatabase WithMigrationAction(Action<TMigration> beforeMigration = null)
+diff --git a/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs b/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
+index 0da5fb02afb0deb75bbe12d24506148bd6573064..d9ac14fc760c4102ba986e0052e27a19ea6f1e7b 100644
+--- a/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
++++ b/src/NzbDrone.Core.Test/IndexerSearchTests/ReleaseSearchServiceFixture.cs
+@@ -12,6 +12,7 @@
+ using NzbDrone.Core.Indexers;
+ using NzbDrone.Core.IndexerSearch;
+ using NzbDrone.Core.IndexerSearch.Definitions;
++using NzbDrone.Core.Parser.Model;
+ using NzbDrone.Core.Test.Framework;
+ using NzbDrone.Core.Tv;
+ 
+@@ -569,6 +570,225 @@ public async Task getscenenames_should_use_seasonnumber_if_no_scene_seasonnumber
+             allCriteria.First().As<SeasonSearchCriteria>().SeasonNumber.Should().Be(7);
+         }
+ 
++        private void SetupAnimeSeasonWithApprovedDecisions(List<Episode> coveredEpisodes)
++        {
++            var remoteEpisode = new RemoteEpisode
++            {
++                Release = new ReleaseInfo { Guid = "test-season-pack-1", Title = "Test Season Pack" },
++                Episodes = coveredEpisodes,
++                Series = _xemSeries
++            };
++
++            var approvedDecision = new DownloadDecision(remoteEpisode);
++            var approvedList = new List<DownloadDecision> { approvedDecision };
++
++            Mocker.GetMock<IMakeDownloadDecision>()
++                .Setup(s => s.GetSearchDecision(It.IsAny<List<ReleaseInfo>>(), It.IsAny<SearchCriteriaBase>()))
++                .Returns<List<ReleaseInfo>, SearchCriteriaBase>((reports, criteria) =>
++                    criteria is AnimeSeasonSearchCriteria ? approvedList : new List<DownloadDecision>());
++        }
++
++        private void WithAnimeEpisode(int id, int seasonNumber, int episodeNumber, int absoluteEpisodeNumber)
++        {
++            var episode = Builder<Episode>.CreateNew()
++                .With(v => v.Id, id)
++                .With(v => v.SeriesId, _xemSeries.Id)
++                .With(v => v.Series, _xemSeries)
++                .With(v => v.SeasonNumber, seasonNumber)
++                .With(v => v.EpisodeNumber, episodeNumber)
++                .With(v => v.AbsoluteEpisodeNumber, absoluteEpisodeNumber)
++                .With(v => v.SceneSeasonNumber, (int?)null)
++                .With(v => v.SceneEpisodeNumber, (int?)null)
++                .With(v => v.SceneAbsoluteEpisodeNumber, (int?)null)
++                .With(v => v.AirDate, $"{2000 + seasonNumber}-{(episodeNumber % 12) + 1:00}-05")
++                .With(v => v.AirDateUtc, DateTime.UtcNow.AddDays(-30))
++                .With(v => v.Monitored, true)
++                .With(v => v.EpisodeFileId, 0)
++                .Build();
++
++            _xemEpisodes.Add(episode);
++        }
++
++        [Test]
++        public async Task anime_season_search_should_skip_all_episodes_when_fully_covered()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Anime;
++            WithAnimeEpisode(101, 1, 1, 1);
++            WithAnimeEpisode(102, 1, 2, 2);
++
++            var seasonEpisodes = _xemEpisodes.Where(e => e.SeasonNumber == 1).ToList();
++            SetupAnimeSeasonWithApprovedDecisions(seasonEpisodes);
++
++            var allCriteria = WatchForSearchCriteria();
++
++            await Subject.SeasonSearch(_xemSeries.Id, 1, true, false, true, false);
++
++            var animeCriteria = allCriteria.OfType<AnimeEpisodeSearchCriteria>().ToList();
++            animeCriteria.Count.Should().Be(0);
++        }
++
++        [Test]
++        public async Task anime_season_search_should_search_all_episodes_when_none_covered()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Anime;
++            WithAnimeEpisode(201, 1, 1, 1);
++            WithAnimeEpisode(202, 1, 2, 2);
++
++            var allCriteria = WatchForSearchCriteria();
++
++            await Subject.SeasonSearch(_xemSeries.Id, 1, true, false, true, false);
++
++            var animeCriteria = allCriteria.OfType<AnimeEpisodeSearchCriteria>().ToList();
++            animeCriteria.Count.Should().Be(2);
++        }
++
++        [Test]
++        public async Task anime_season_search_should_only_search_uncovered_episodes()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Anime;
++            WithAnimeEpisode(301, 1, 1, 1);
++            WithAnimeEpisode(302, 1, 2, 2);
++
++            // Cover only the first episode
++            SetupAnimeSeasonWithApprovedDecisions(new List<Episode> { _xemEpisodes.First() });
++
++            var allCriteria = WatchForSearchCriteria();
++
++            await Subject.SeasonSearch(_xemSeries.Id, 1, true, false, true, false);
++
++            var animeCriteria = allCriteria.OfType<AnimeEpisodeSearchCriteria>().ToList();
++            animeCriteria.Count.Should().Be(1);
++        }
++
++        [Test]
++        public async Task anime_season_0_search_should_use_special_search_not_anime_season_search()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Anime;
++            WithAnimeEpisode(401, 0, 1, 0);
++
++            var allCriteria = WatchForSearchCriteria();
++
++            await Subject.SeasonSearch(_xemSeries.Id, 0, false, false, true, false);
++
++            var animeCriteria = allCriteria.OfType<AnimeSeasonSearchCriteria>().ToList();
++            animeCriteria.Count.Should().Be(0, "Season 0 should not use AnimeSeasonSearchCriteria");
++
++            var specialCriteria = allCriteria.OfType<SpecialEpisodeSearchCriteria>().ToList();
++            specialCriteria.Count.Should().Be(1, "Season 0 should use SpecialEpisodeSearchCriteria");
++        }
++
++        [Test]
++        public async Task anime_season_0_search_should_not_affect_season_1_routing()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Anime;
++            WithAnimeEpisode(501, 1, 1, 1);
++            WithAnimeEpisode(502, 1, 2, 2);
++
++            var allCriteria = WatchForSearchCriteria();
++
++            await Subject.SeasonSearch(_xemSeries.Id, 1, true, false, true, false);
++
++            var animeCriteria = allCriteria.OfType<AnimeSeasonSearchCriteria>().ToList();
++            animeCriteria.Count.Should().BeGreaterThan(0, "Season 1 should still use AnimeSeasonSearchCriteria");
++
++            var specialCriteria = allCriteria.OfType<SpecialEpisodeSearchCriteria>().ToList();
++            specialCriteria.Count.Should().Be(0, "Season 1 should not use SpecialEpisodeSearchCriteria");
++        }
++
++        [Test]
++        public async Task multi_season_anime_search_should_accumulate_broad_queries_across_seasons()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Anime;
++            WithAnimeEpisode(101, 1, 1, 1);
++            WithAnimeEpisode(102, 1, 2, 2);
++            WithAnimeEpisode(201, 2, 1, 13);
++            WithAnimeEpisode(202, 2, 2, 14);
++
++            WatchForSearchCriteria();
++
++            var broadEmitted = new HashSet<string>();
++            await Subject.SeasonSearch(_xemSeries.Id, 1, true, false, true, false, broadEmitted);
++
++            // After S1, broadEmitted should contain the series' scene titles
++            broadEmitted.Should().NotBeEmpty();
++            broadEmitted.Should().Contain(_xemSeries.Title);
++        }
++
++        [Test]
++        public async Task multi_season_anime_search_should_pass_accumulated_broad_queries_to_later_seasons()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Anime;
++            WithAnimeEpisode(101, 1, 1, 1);
++            WithAnimeEpisode(102, 1, 2, 2);
++            WithAnimeEpisode(201, 2, 1, 13);
++            WithAnimeEpisode(202, 2, 2, 14);
++
++            // Capture BroadQueriesEmitted snapshots at the time of each Fetch
++            var broadSnapshots = new List<string[]>();
++            _mockIndexer.Setup(v => v.Fetch(It.IsAny<AnimeSeasonSearchCriteria>()))
++                .Callback<AnimeSeasonSearchCriteria>(s =>
++                    broadSnapshots.Add(s.BroadQueriesEmitted?.ToArray() ?? Array.Empty<string>()))
++                .Returns(Task.FromResult<IList<ReleaseInfo>>(new List<ReleaseInfo>()));
++
++            _mockIndexer.Setup(v => v.Fetch(It.IsAny<AnimeEpisodeSearchCriteria>()))
++                .Returns(Task.FromResult<IList<ReleaseInfo>>(new List<ReleaseInfo>()));
++
++            var broadEmitted = new HashSet<string>();
++            await Subject.SeasonSearch(_xemSeries.Id, 1, true, false, true, false, broadEmitted);
++            await Subject.SeasonSearch(_xemSeries.Id, 2, true, false, true, false, broadEmitted);
++
++            broadSnapshots.Should().HaveCount(2);
++
++            // S1 should receive empty emitted set (no prior seasons)
++            broadSnapshots[0].Should().BeEmpty();
++
++            // S2 should receive the titles that S1 added
++            broadSnapshots[1].Should().NotBeEmpty();
++            broadSnapshots[1].Should().Contain(_xemSeries.Title);
++        }
++
++        [Test]
++        public async Task anime_season_0_should_not_pollute_cross_season_broad_query_state()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Anime;
++            WithAnimeEpisode(401, 0, 1, 0);
++
++            WatchForSearchCriteria();
++
++            var broadEmitted = new HashSet<string>();
++            await Subject.SeasonSearch(_xemSeries.Id, 0, false, false, true, false, broadEmitted);
++
++            // Season 0 uses SpecialEpisodeSearchCriteria, should not touch broadEmitted
++            broadEmitted.Should().BeEmpty();
++        }
++
++        [Test]
++        public async Task broad_query_state_should_deduplicate_scene_titles()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Anime;
++            _xemSeries.Title = "Test Anime";
++            WithAnimeEpisode(101, 1, 1, 1);
++            WithAnimeEpisode(102, 1, 2, 2);
++
++            Mocker.GetMock<ISeriesService>()
++                .Setup(v => v.GetSeries(_xemSeries.Id))
++                .Returns(_xemSeries);
++
++            // Scene mapping returns duplicate titles
++            Mocker.GetMock<ISceneMappingService>()
++                .Setup(s => s.GetSceneNames(It.IsAny<int>(), It.IsAny<List<int>>(), It.IsAny<List<int>>()))
++                .Returns(new List<string> { "Test Anime", "Test Anime" });
++
++            WatchForSearchCriteria();
++
++            var broadEmitted = new HashSet<string>();
++            await Subject.SeasonSearch(_xemSeries.Id, 1, true, false, true, false, broadEmitted);
++
++            // HashSet should naturally deduplicate — "Test Anime" appears twice in SceneTitles
++            // but UnionWith deduplicates
++            broadEmitted.Should().HaveCount(1);
++        }
++
+         [Test]
+         public async Task episode_search_should_use_all_available_numbering_from_services_and_xem()
+         {
+@@ -650,5 +870,208 @@ public async Task episode_search_should_include_series_title_when_not_a_direct_t
+             allCriteria.Last().As<SingleEpisodeSearchCriteria>().SeasonNumber.Should().Be(2);
+             allCriteria.Last().As<SingleEpisodeSearchCriteria>().EpisodeNumber.Should().Be(3);
+         }
++
++        [Test]
++        public async Task anime_season_search_should_exclude_cross_season_covered_episodes_from_fallback()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Anime;
++            WithAnimeEpisode(301, 1, 1, 1);
++            WithAnimeEpisode(302, 1, 2, 2);
++
++            // No approved results from season search (so within-season coverage is empty)
++            // but episode 301 is already covered by cross-season grab
++            var alreadyCovered = new HashSet<int> { 301 };
++
++            var allCriteria = WatchForSearchCriteria();
++
++            await Subject.SeasonSearch(_xemSeries.Id, 1, true, false, true, false, null, alreadyCovered);
++
++            // Only the uncovered episode (302) should get an individual search
++            var animeCriteria = allCriteria.OfType<AnimeEpisodeSearchCriteria>().ToList();
++            animeCriteria.Count.Should().Be(1);
++            animeCriteria[0].AbsoluteEpisodeNumber.Should().Be(2);
++        }
++
++        [Test]
++        public async Task anime_season_search_should_skip_all_when_cross_season_covers_everything()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Anime;
++            WithAnimeEpisode(301, 1, 1, 1);
++            WithAnimeEpisode(302, 1, 2, 2);
++
++            // Both episodes already covered by cross-season grabs
++            var alreadyCovered = new HashSet<int> { 301, 302 };
++
++            var allCriteria = WatchForSearchCriteria();
++
++            await Subject.SeasonSearch(_xemSeries.Id, 1, true, false, true, false, null, alreadyCovered);
++
++            // No individual episode searches should happen
++            var animeCriteria = allCriteria.OfType<AnimeEpisodeSearchCriteria>().ToList();
++            animeCriteria.Count.Should().Be(0);
++        }
++
++        [Test]
++        public async Task anime_season_search_should_combine_season_and_cross_season_coverage()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Anime;
++            WithAnimeEpisode(301, 1, 1, 1);
++            WithAnimeEpisode(302, 1, 2, 2);
++            WithAnimeEpisode(303, 1, 3, 3);
++
++            // Episode 301 covered by cross-season grab
++            var alreadyCovered = new HashSet<int> { 301 };
++
++            // Episode 302 covered by approved season search result
++            SetupAnimeSeasonWithApprovedDecisions(new List<Episode> { _xemEpisodes[1] });
++
++            var allCriteria = WatchForSearchCriteria();
++
++            await Subject.SeasonSearch(_xemSeries.Id, 1, true, false, true, false, null, alreadyCovered);
++
++            // Only episode 303 (uncovered by both) should get individual search
++            var animeCriteria = allCriteria.OfType<AnimeEpisodeSearchCriteria>().ToList();
++            animeCriteria.Count.Should().Be(1);
++            animeCriteria[0].AbsoluteEpisodeNumber.Should().Be(3);
++        }
++
++        [Test]
++        public async Task anime_multi_episode_approved_result_should_only_suppress_mapped_episodes()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Anime;
++            WithAnimeEpisode(301, 1, 1, 1);
++            WithAnimeEpisode(302, 1, 2, 2);
++            WithAnimeEpisode(303, 1, 3, 3);
++
++            // Approved result covers episodes 1 and 2 only (multi-episode release)
++            var ep1 = _xemEpisodes[0];
++            var ep2 = _xemEpisodes[1];
++            SetupAnimeSeasonWithApprovedDecisions(new List<Episode> { ep1, ep2 });
++
++            var allCriteria = WatchForSearchCriteria();
++
++            await Subject.SeasonSearch(_xemSeries.Id, 1, true, false, true, false);
++
++            // Only episode 3 should get individual search
++            var animeCriteria = allCriteria.OfType<AnimeEpisodeSearchCriteria>().ToList();
++            animeCriteria.Count.Should().Be(1);
++            animeCriteria[0].AbsoluteEpisodeNumber.Should().Be(3);
++        }
++
++        [Test]
++        public async Task standard_series_season_search_should_not_use_anime_cascade()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Standard;
++            WithEpisode(1, 1, null, null);
++            WithEpisode(1, 2, null, null);
++
++            var allCriteria = WatchForSearchCriteria();
++
++            await Subject.SeasonSearch(_xemSeries.Id, 1, false, false, true, false);
++
++            // Standard series should use SeasonSearchCriteria, not anime criteria
++            var seasonCriteria = allCriteria.OfType<SeasonSearchCriteria>().ToList();
++            seasonCriteria.Count.Should().BeGreaterThan(0);
++
++            var animeCriteria = allCriteria.OfType<AnimeSeasonSearchCriteria>().ToList();
++            animeCriteria.Count.Should().Be(0);
++
++            var animeEpCriteria = allCriteria.OfType<AnimeEpisodeSearchCriteria>().ToList();
++            animeEpCriteria.Count.Should().Be(0);
++        }
++
++        private void SetupSpecialSearchWithApprovedDecisions(List<Episode> coveredEpisodes)
++        {
++            var remoteEpisode = new RemoteEpisode
++            {
++                Release = new ReleaseInfo { Guid = "test-special-pack-1", Title = "Test Special Pack" },
++                Episodes = coveredEpisodes,
++                Series = _xemSeries
++            };
++
++            var approvedDecision = new DownloadDecision(remoteEpisode);
++            var approvedList = new List<DownloadDecision> { approvedDecision };
++
++            Mocker.GetMock<IMakeDownloadDecision>()
++                .Setup(s => s.GetSearchDecision(It.IsAny<List<ReleaseInfo>>(), It.IsAny<SearchCriteriaBase>()))
++                .Returns<List<ReleaseInfo>, SearchCriteriaBase>((reports, criteria) =>
++                    criteria is SpecialEpisodeSearchCriteria ? approvedList : new List<DownloadDecision>());
++        }
++
++        [Test]
++        public async Task special_search_should_skip_per_episode_fallback_when_fully_covered()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Anime;
++            WithAnimeEpisode(401, 0, 1, 0);
++            WithAnimeEpisode(402, 0, 2, 0);
++
++            var specialEpisodes = _xemEpisodes.Where(e => e.SeasonNumber == 0).ToList();
++            SetupSpecialSearchWithApprovedDecisions(specialEpisodes);
++
++            var allCriteria = WatchForSearchCriteria();
++
++            await Subject.SeasonSearch(_xemSeries.Id, 0, false, false, true, false);
++
++            // No SingleEpisodeSearchCriteria should fire — specials are fully covered
++            var singleCriteria = allCriteria.OfType<SingleEpisodeSearchCriteria>().ToList();
++            singleCriteria.Count.Should().Be(0);
++        }
++
++        [Test]
++        public async Task special_search_should_only_search_uncovered_specials()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Anime;
++            WithAnimeEpisode(401, 0, 1, 0);
++            WithAnimeEpisode(402, 0, 2, 0);
++
++            // Only the first special is covered
++            SetupSpecialSearchWithApprovedDecisions(new List<Episode> { _xemEpisodes[0] });
++
++            var allCriteria = WatchForSearchCriteria();
++
++            await Subject.SeasonSearch(_xemSeries.Id, 0, false, false, true, false);
++
++            // Only the second special (uncovered) should get a per-episode search
++            var singleCriteria = allCriteria.OfType<SingleEpisodeSearchCriteria>().ToList();
++            singleCriteria.Count.Should().Be(1);
++            singleCriteria[0].EpisodeNumber.Should().Be(2);
++        }
++
++        [Test]
++        public async Task special_search_should_fall_through_all_when_none_covered()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Anime;
++            WithAnimeEpisode(401, 0, 1, 0);
++            WithAnimeEpisode(402, 0, 2, 0);
++
++            // No approved results for special search
++            var allCriteria = WatchForSearchCriteria();
++
++            await Subject.SeasonSearch(_xemSeries.Id, 0, false, false, true, false);
++
++            // Both specials should get per-episode search
++            var singleCriteria = allCriteria.OfType<SingleEpisodeSearchCriteria>().ToList();
++            singleCriteria.Count.Should().Be(2);
++        }
++
++        [Test]
++        public async Task special_search_should_not_search_unmonitored_specials_in_fallback()
++        {
++            _xemSeries.SeriesType = SeriesTypes.Anime;
++            WithAnimeEpisode(401, 0, 1, 0);
++            WithAnimeEpisode(402, 0, 2, 0);
++
++            // Make second special unmonitored
++            _xemEpisodes[1].Monitored = false;
++
++            var allCriteria = WatchForSearchCriteria();
++
++            await Subject.SeasonSearch(_xemSeries.Id, 0, false, true, true, false);
++
++            // Only the monitored special should get a per-episode search
++            var singleCriteria = allCriteria.OfType<SingleEpisodeSearchCriteria>().ToList();
++            singleCriteria.Count.Should().Be(1);
++            singleCriteria[0].EpisodeNumber.Should().Be(1);
++        }
+     }
+ }
+diff --git a/src/NzbDrone.Core.Test/IndexerSearchTests/SeriesSearchServiceFixture.cs b/src/NzbDrone.Core.Test/IndexerSearchTests/SeriesSearchServiceFixture.cs
+index ab6ab0755250a549860eccad41a530bee901e335..08fb4a247b768d3bb22bf88f3f3925cd7f13105a 100644
+--- a/src/NzbDrone.Core.Test/IndexerSearchTests/SeriesSearchServiceFixture.cs
++++ b/src/NzbDrone.Core.Test/IndexerSearchTests/SeriesSearchServiceFixture.cs
+@@ -1,6 +1,7 @@
+ using System.Collections.Generic;
+ using System.Linq;
+ using System.Threading.Tasks;
++using FizzWare.NBuilder;
+ using FluentAssertions;
+ using Moq;
+ using NUnit.Framework;
+@@ -8,6 +9,7 @@
+ using NzbDrone.Core.Download;
+ using NzbDrone.Core.IndexerSearch;
+ using NzbDrone.Core.Messaging.Commands;
++using NzbDrone.Core.Parser.Model;
+ using NzbDrone.Core.Test.Framework;
+ using NzbDrone.Core.Tv;
+ 
+@@ -36,6 +38,10 @@ public void Setup()
+                   .Setup(s => s.SeasonSearch(_series.Id, It.IsAny<int>(), false, false, true, false))
+                   .Returns(Task.FromResult(new List<DownloadDecision>()));
+ 
++            Mocker.GetMock<ISearchForReleases>()
++                  .Setup(s => s.SeasonSearch(_series.Id, It.IsAny<int>(), false, true, true, false, It.IsAny<HashSet<string>>(), It.IsAny<HashSet<int>>()))
++                  .Returns(Task.FromResult(new List<DownloadDecision>()));
++
+             Mocker.GetMock<IProcessDownloadDecisions>()
+                   .Setup(s => s.ProcessDecisions(It.IsAny<List<DownloadDecision>>()))
+                   .Returns(Task.FromResult(new ProcessedDecisions(new List<DownloadDecision>(), new List<DownloadDecision>(), new List<DownloadDecision>())));
+@@ -77,5 +83,348 @@ public void should_start_with_lower_seasons_first()
+ 
+             seasonOrder.First().Should().Be(_series.Seasons.OrderBy(s => s.SeasonNumber).First().SeasonNumber);
+         }
++
++        [Test]
++        public void should_skip_later_anime_season_when_earlier_grab_already_covers_it()
++        {
++            var seasonSearches = new List<int>();
++            var season1Episode = Builder<Episode>.CreateNew()
++                .With(e => e.Id = 11)
++                .With(e => e.SeriesId = _series.Id)
++                .With(e => e.SeasonNumber = 1)
++                .With(e => e.Monitored = true)
++                .With(e => e.EpisodeFileId = 0)
++                .With(e => e.AirDateUtc = System.DateTime.UtcNow.AddDays(-1))
++                .Build();
++            var season2Episode = Builder<Episode>.CreateNew()
++                .With(e => e.Id = 22)
++                .With(e => e.SeriesId = _series.Id)
++                .With(e => e.SeasonNumber = 2)
++                .With(e => e.Monitored = true)
++                .With(e => e.EpisodeFileId = 0)
++                .With(e => e.AirDateUtc = System.DateTime.UtcNow.AddDays(-1))
++                .Build();
++
++            _series.SeriesType = SeriesTypes.Anime;
++            _series.Seasons = new List<Season>
++            {
++                new Season { SeasonNumber = 1, Monitored = true },
++                new Season { SeasonNumber = 2, Monitored = true }
++            };
++
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 1))
++                .Returns(new List<Episode> { season1Episode });
++
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 2))
++                .Returns(new List<Episode> { season2Episode });
++
++            Mocker.GetMock<ISearchForReleases>()
++                .Setup(s => s.SeasonSearch(_series.Id, It.IsAny<int>(), false, true, true, false, It.IsAny<HashSet<string>>(), It.IsAny<HashSet<int>>()))
++                .Returns(Task.FromResult(new List<DownloadDecision>()))
++                .Callback<int, int, bool, bool, bool, bool, HashSet<string>, HashSet<int>>((seriesId, seasonNumber, missingOnly, monitoredOnly, userInvokedSearch, interactiveSearch, broadQueries, coveredIds) => seasonSearches.Add(seasonNumber));
++
++            var grabbedDecision = new DownloadDecision(new RemoteEpisode
++            {
++                Episodes = new List<Episode> { season1Episode, season2Episode },
++                ParsedEpisodeInfo = new ParsedEpisodeInfo()
++            });
++
++            Mocker.GetMock<IProcessDownloadDecisions>()
++                .SetupSequence(s => s.ProcessDecisions(It.IsAny<List<DownloadDecision>>()))
++                .Returns(Task.FromResult(new ProcessedDecisions(new List<DownloadDecision> { grabbedDecision }, new List<DownloadDecision>(), new List<DownloadDecision>())));
++
++            Subject.Execute(new SeriesSearchCommand { SeriesId = _series.Id, Trigger = CommandTrigger.Manual });
++
++            seasonSearches.Should().Equal(1);
++        }
++
++        [Test]
++        public void should_search_anime_non_zero_seasons_before_season_zero()
++        {
++            var seasonSearches = new List<int>();
++
++            _series.SeriesType = SeriesTypes.Anime;
++            _series.Seasons = new List<Season>
++            {
++                new Season { SeasonNumber = 0, Monitored = true },
++                new Season { SeasonNumber = 1, Monitored = true },
++                new Season { SeasonNumber = 2, Monitored = true }
++            };
++
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, It.IsAny<int>()))
++                .Returns<int, int>((seriesId, seasonNumber) => new List<Episode>
++                {
++                    Builder<Episode>.CreateNew()
++                        .With(e => e.Id = (seasonNumber * 10) + 1)
++                        .With(e => e.SeriesId = seriesId)
++                        .With(e => e.SeasonNumber = seasonNumber)
++                        .With(e => e.Monitored = true)
++                        .With(e => e.EpisodeFileId = 0)
++                        .With(e => e.AirDateUtc = System.DateTime.UtcNow.AddDays(-1))
++                        .Build()
++                });
++
++            Mocker.GetMock<ISearchForReleases>()
++                .Setup(s => s.SeasonSearch(_series.Id, It.IsAny<int>(), false, true, true, false, It.IsAny<HashSet<string>>(), It.IsAny<HashSet<int>>()))
++                .Returns(Task.FromResult(new List<DownloadDecision>()))
++                .Callback<int, int, bool, bool, bool, bool, HashSet<string>, HashSet<int>>((seriesId, seasonNumber, missingOnly, monitoredOnly, userInvokedSearch, interactiveSearch, broadQueries, coveredIds) => seasonSearches.Add(seasonNumber));
++
++            Subject.Execute(new SeriesSearchCommand { SeriesId = _series.Id, Trigger = CommandTrigger.Manual });
++
++            seasonSearches.Should().Equal(1, 2, 0);
++        }
++
++        [Test]
++        public void should_not_reorder_standard_series_seasons()
++        {
++            var seasonSearches = new List<int>();
++
++            _series.SeriesType = SeriesTypes.Standard;
++            _series.Seasons = new List<Season>
++            {
++                new Season { SeasonNumber = 0, Monitored = true },
++                new Season { SeasonNumber = 1, Monitored = true },
++                new Season { SeasonNumber = 2, Monitored = true }
++            };
++
++            Mocker.GetMock<ISearchForReleases>()
++                .Setup(s => s.SeasonSearch(_series.Id, It.IsAny<int>(), false, true, true, false))
++                .Returns(Task.FromResult(new List<DownloadDecision>()))
++                .Callback<int, int, bool, bool, bool, bool>((seriesId, seasonNumber, missingOnly, monitoredOnly, userInvokedSearch, interactiveSearch) => seasonSearches.Add(seasonNumber));
++
++            Subject.Execute(new SeriesSearchCommand { SeriesId = _series.Id, Trigger = CommandTrigger.Manual });
++
++            seasonSearches.Should().Equal(0, 1, 2);
++        }
++
++        [Test]
++        public void should_skip_season_zero_when_earlier_grab_covers_wanted_special()
++        {
++            var seasonSearches = new List<int>();
++            var season1Episode = Builder<Episode>.CreateNew()
++                .With(e => e.Id = 11)
++                .With(e => e.SeriesId = _series.Id)
++                .With(e => e.SeasonNumber = 1)
++                .With(e => e.Monitored = true)
++                .With(e => e.EpisodeFileId = 0)
++                .With(e => e.AirDateUtc = System.DateTime.UtcNow.AddDays(-1))
++                .Build();
++            var season0Special = Builder<Episode>.CreateNew()
++                .With(e => e.Id = 99)
++                .With(e => e.SeriesId = _series.Id)
++                .With(e => e.SeasonNumber = 0)
++                .With(e => e.Monitored = true)
++                .With(e => e.EpisodeFileId = 0)
++                .With(e => e.AirDateUtc = System.DateTime.UtcNow.AddDays(-1))
++                .Build();
++
++            _series.SeriesType = SeriesTypes.Anime;
++            _series.Seasons = new List<Season>
++            {
++                new Season { SeasonNumber = 0, Monitored = true },
++                new Season { SeasonNumber = 1, Monitored = true }
++            };
++
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 0))
++                .Returns(new List<Episode> { season0Special });
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 1))
++                .Returns(new List<Episode> { season1Episode });
++
++            Mocker.GetMock<ISearchForReleases>()
++                .Setup(s => s.SeasonSearch(_series.Id, It.IsAny<int>(), false, true, true, false, It.IsAny<HashSet<string>>(), It.IsAny<HashSet<int>>()))
++                .Returns(Task.FromResult(new List<DownloadDecision>()))
++                .Callback<int, int, bool, bool, bool, bool, HashSet<string>, HashSet<int>>((seriesId, seasonNumber, missingOnly, monitoredOnly, userInvokedSearch, interactiveSearch, broadQueries, coveredIds) => seasonSearches.Add(seasonNumber));
++
++            // The S01 grab covers both S01 episode and S00 special (S01+Specials pack)
++            var grabbedDecision = new DownloadDecision(new RemoteEpisode
++            {
++                Episodes = new List<Episode> { season1Episode, season0Special },
++                ParsedEpisodeInfo = new ParsedEpisodeInfo()
++            });
++
++            Mocker.GetMock<IProcessDownloadDecisions>()
++                .SetupSequence(s => s.ProcessDecisions(It.IsAny<List<DownloadDecision>>()))
++                .Returns(Task.FromResult(new ProcessedDecisions(new List<DownloadDecision> { grabbedDecision }, new List<DownloadDecision>(), new List<DownloadDecision>())));
++
++            Subject.Execute(new SeriesSearchCommand { SeriesId = _series.Id, Trigger = CommandTrigger.Manual });
++
++            // S01 is searched, S00 is skipped because the grab covered the special
++            seasonSearches.Should().Equal(1);
++        }
++
++        [Test]
++        public void should_not_skip_later_anime_season_on_partial_coverage()
++        {
++            var seasonSearches = new List<int>();
++            var season1Episode = Builder<Episode>.CreateNew()
++                .With(e => e.Id = 11)
++                .With(e => e.SeriesId = _series.Id)
++                .With(e => e.SeasonNumber = 1)
++                .With(e => e.Monitored = true)
++                .With(e => e.EpisodeFileId = 0)
++                .With(e => e.AirDateUtc = System.DateTime.UtcNow.AddDays(-1))
++                .Build();
++            var season2Episode1 = Builder<Episode>.CreateNew()
++                .With(e => e.Id = 21)
++                .With(e => e.SeriesId = _series.Id)
++                .With(e => e.SeasonNumber = 2)
++                .With(e => e.Monitored = true)
++                .With(e => e.EpisodeFileId = 0)
++                .With(e => e.AirDateUtc = System.DateTime.UtcNow.AddDays(-1))
++                .Build();
++            var season2Episode2 = Builder<Episode>.CreateNew()
++                .With(e => e.Id = 22)
++                .With(e => e.SeriesId = _series.Id)
++                .With(e => e.SeasonNumber = 2)
++                .With(e => e.Monitored = true)
++                .With(e => e.EpisodeFileId = 0)
++                .With(e => e.AirDateUtc = System.DateTime.UtcNow.AddDays(-1))
++                .Build();
++
++            _series.SeriesType = SeriesTypes.Anime;
++            _series.Seasons = new List<Season>
++            {
++                new Season { SeasonNumber = 1, Monitored = true },
++                new Season { SeasonNumber = 2, Monitored = true }
++            };
++
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 1))
++                .Returns(new List<Episode> { season1Episode });
++
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 2))
++                .Returns(new List<Episode> { season2Episode1, season2Episode2 });
++
++            Mocker.GetMock<ISearchForReleases>()
++                .Setup(s => s.SeasonSearch(_series.Id, It.IsAny<int>(), false, true, true, false, It.IsAny<HashSet<string>>(), It.IsAny<HashSet<int>>()))
++                .Returns(Task.FromResult(new List<DownloadDecision>()))
++                .Callback<int, int, bool, bool, bool, bool, HashSet<string>, HashSet<int>>((seriesId, seasonNumber, missingOnly, monitoredOnly, userInvokedSearch, interactiveSearch, broadQueries, coveredIds) => seasonSearches.Add(seasonNumber));
++
++            // S1 grab covers S1 episode and only ONE of the two S2 episodes (partial coverage)
++            var grabbedDecision = new DownloadDecision(new RemoteEpisode
++            {
++                Episodes = new List<Episode> { season1Episode, season2Episode1 },
++                ParsedEpisodeInfo = new ParsedEpisodeInfo()
++            });
++
++            Mocker.GetMock<IProcessDownloadDecisions>()
++                .SetupSequence(s => s.ProcessDecisions(It.IsAny<List<DownloadDecision>>()))
++                .Returns(Task.FromResult(new ProcessedDecisions(new List<DownloadDecision> { grabbedDecision }, new List<DownloadDecision>(), new List<DownloadDecision>())))
++                .Returns(Task.FromResult(new ProcessedDecisions(new List<DownloadDecision>(), new List<DownloadDecision>(), new List<DownloadDecision>())));
++
++            Subject.Execute(new SeriesSearchCommand { SeriesId = _series.Id, Trigger = CommandTrigger.Manual });
++
++            // S2 must still be searched because only 1 of 2 wanted episodes is covered
++            seasonSearches.Should().Equal(1, 2);
++        }
++
++        [Test]
++        public void should_pass_covered_episode_ids_to_later_season_search()
++        {
++            HashSet<int> capturedCoveredIds = null;
++            var season1Episode = Builder<Episode>.CreateNew()
++                .With(e => e.Id = 11)
++                .With(e => e.SeriesId = _series.Id)
++                .With(e => e.SeasonNumber = 1)
++                .With(e => e.Monitored = true)
++                .With(e => e.EpisodeFileId = 0)
++                .With(e => e.AirDateUtc = System.DateTime.UtcNow.AddDays(-1))
++                .Build();
++            var season2Episode1 = Builder<Episode>.CreateNew()
++                .With(e => e.Id = 21)
++                .With(e => e.SeriesId = _series.Id)
++                .With(e => e.SeasonNumber = 2)
++                .With(e => e.Monitored = true)
++                .With(e => e.EpisodeFileId = 0)
++                .With(e => e.AirDateUtc = System.DateTime.UtcNow.AddDays(-1))
++                .Build();
++            var season2Episode2 = Builder<Episode>.CreateNew()
++                .With(e => e.Id = 22)
++                .With(e => e.SeriesId = _series.Id)
++                .With(e => e.SeasonNumber = 2)
++                .With(e => e.Monitored = true)
++                .With(e => e.EpisodeFileId = 0)
++                .With(e => e.AirDateUtc = System.DateTime.UtcNow.AddDays(-1))
++                .Build();
++
++            _series.SeriesType = SeriesTypes.Anime;
++            _series.Seasons = new List<Season>
++            {
++                new Season { SeasonNumber = 1, Monitored = true },
++                new Season { SeasonNumber = 2, Monitored = true }
++            };
++
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 1))
++                .Returns(new List<Episode> { season1Episode });
++
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 2))
++                .Returns(new List<Episode> { season2Episode1, season2Episode2 });
++
++            Mocker.GetMock<ISearchForReleases>()
++                .Setup(s => s.SeasonSearch(_series.Id, It.IsAny<int>(), false, true, true, false, It.IsAny<HashSet<string>>(), It.IsAny<HashSet<int>>()))
++                .Returns(Task.FromResult(new List<DownloadDecision>()))
++                .Callback<int, int, bool, bool, bool, bool, HashSet<string>, HashSet<int>>((seriesId, seasonNumber, missingOnly, monitoredOnly, userInvokedSearch, interactiveSearch, broadQueries, coveredIds) =>
++                {
++                    if (seasonNumber == 2)
++                    {
++                        capturedCoveredIds = coveredIds != null ? new HashSet<int>(coveredIds) : null;
++                    }
++                });
++
++            // S1 grab covers S1 episode and one S2 episode
++            var grabbedDecision = new DownloadDecision(new RemoteEpisode
++            {
++                Episodes = new List<Episode> { season1Episode, season2Episode1 },
++                ParsedEpisodeInfo = new ParsedEpisodeInfo()
++            });
++
++            Mocker.GetMock<IProcessDownloadDecisions>()
++                .SetupSequence(s => s.ProcessDecisions(It.IsAny<List<DownloadDecision>>()))
++                .Returns(Task.FromResult(new ProcessedDecisions(new List<DownloadDecision> { grabbedDecision }, new List<DownloadDecision>(), new List<DownloadDecision>())))
++                .Returns(Task.FromResult(new ProcessedDecisions(new List<DownloadDecision>(), new List<DownloadDecision>(), new List<DownloadDecision>())));
++
++            Subject.Execute(new SeriesSearchCommand { SeriesId = _series.Id, Trigger = CommandTrigger.Manual });
++
++            // The covered IDs passed to S2 should contain both grabbed episode IDs
++            capturedCoveredIds.Should().NotBeNull();
++            capturedCoveredIds.Should().Contain(11);
++            capturedCoveredIds.Should().Contain(21);
++        }
++
++        [Test]
++        public void should_not_skip_or_reorder_standard_series_with_anime_skip_logic()
++        {
++            var seasonSearches = new List<int>();
++
++            _series.SeriesType = SeriesTypes.Standard;
++            _series.Seasons = new List<Season>
++            {
++                new Season { SeasonNumber = 0, Monitored = true },
++                new Season { SeasonNumber = 1, Monitored = true },
++                new Season { SeasonNumber = 2, Monitored = true }
++            };
++
++            Mocker.GetMock<ISearchForReleases>()
++                .Setup(s => s.SeasonSearch(_series.Id, It.IsAny<int>(), false, true, true, false))
++                .Returns(Task.FromResult(new List<DownloadDecision>()))
++                .Callback<int, int, bool, bool, bool, bool>((seriesId, seasonNumber, missingOnly, monitoredOnly, userInvokedSearch, interactiveSearch) => seasonSearches.Add(seasonNumber));
++
++            Subject.Execute(new SeriesSearchCommand { SeriesId = _series.Id, Trigger = CommandTrigger.Manual });
++
++            // Standard series: normal order, no skipping, no anime overload called
++            seasonSearches.Should().Equal(0, 1, 2);
++
++            // Verify the anime-specific overload with broadQueries is never called
++            Mocker.GetMock<ISearchForReleases>()
++                .Verify(s => s.SeasonSearch(_series.Id, It.IsAny<int>(), false, true, true, false, It.IsAny<HashSet<string>>(), It.IsAny<HashSet<int>>()), Times.Never());
++        }
+     }
+ }
+diff --git a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+index b0fc4998b6b26e1cc27f4fd3923ab5c0869ec735..d225db496f1e8c999d4ed7a39e36ac0d4760c891 100644
+--- a/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
++++ b/src/NzbDrone.Core.Test/IndexerTests/NewznabTests/NewznabRequestGeneratorFixture.cs
+@@ -182,6 +182,78 @@ public void should_search_by_standard_season_number()
+             Subject.Settings.AnimeStandardFormatSearch = true;
+             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
+ 
++            results.GetTier(0).Should().HaveCount(3);
++            var pages = results.GetTier(0).Select(t => t.First()).ToList();
++
++            // Broad title-only query first
++            pages[0].Url.FullUri.Should().Contain("?t=search&");
++            pages[0].Url.FullUri.Should().Contain("q=Monkey%20Island");
++            pages[0].Url.FullUri.Should().NotContain("season=");
++
++            // Then season-specific queries
++            pages[1].Url.FullUri.Should().Contain("rid=10&season=3");
++            pages[2].Url.FullUri.Should().Contain("q=Monkey%20Island&season=3");
++        }
++
++        [Test]
++        public void should_emit_broad_query_for_anime_season_search_without_standard_format()
++        {
++            Subject.Settings.AnimeStandardFormatSearch = false;
++            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            results.GetTier(0).Should().HaveCount(1);
++
++            var page = results.GetTier(0).First().First();
++            page.Url.FullUri.Should().Contain("?t=search&");
++            page.Url.FullUri.Should().Contain("q=Monkey%20Island");
++            page.Url.FullUri.Should().NotContain("season=");
++        }
++
++        [Test]
++        public void should_use_anime_categories_for_anime_season_broad_query()
++        {
++            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            results.GetTier(0).Should().HaveCount(1);
++
++            var page = results.GetTier(0).First().First();
++            page.Url.FullUri.Should().Contain("&cat=3,4&");
++        }
++
++        [Test]
++        public void should_deduplicate_identical_scene_titles_for_anime_season_search()
++        {
++            Subject.Settings.AnimeStandardFormatSearch = true;
++            _animeSeasonSearchCriteria.SceneTitles = new List<string> { "Monkey Island", "Monkey Island", "Other Title" };
++
++            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            // 2 broad + 1 ID-based season + 2 title-based season = 5
++            var pages = results.GetTier(0).Select(t => t.First()).ToList();
++            pages.Should().HaveCount(5);
++
++            // Broad queries (deduplicated)
++            pages[0].Url.FullUri.Should().Contain("?t=search&");
++            pages[0].Url.FullUri.Should().Contain("q=Monkey%20Island");
++            pages[1].Url.FullUri.Should().Contain("?t=search&");
++            pages[1].Url.FullUri.Should().Contain("q=Other%20Title");
++
++            // Season-specific
++            pages[2].Url.FullUri.Should().Contain("rid=10&season=3");
++            pages[3].Url.FullUri.Should().Contain("q=Monkey%20Island&season=3");
++            pages[4].Url.FullUri.Should().Contain("q=Other%20Title&season=3");
++        }
++
++        [Test]
++        public void should_suppress_anime_season_broad_query_already_emitted()
++        {
++            Subject.Settings.AnimeStandardFormatSearch = true;
++
++            _animeSeasonSearchCriteria.BroadQueriesEmitted = new HashSet<string> { "Monkey Island" };
++
++            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            // Only season-specific queries remain (ID + title)
+             results.GetTier(0).Should().HaveCount(2);
+             var pages = results.GetTier(0).Select(t => t.First()).ToList();
+ 
+@@ -189,6 +261,103 @@ public void should_search_by_standard_season_number()
+             pages[1].Url.FullUri.Should().Contain("q=Monkey%20Island&season=3");
+         }
+ 
++        [Test]
++        public void should_emit_anime_season_broad_query_when_emitted_set_is_empty()
++        {
++            Subject.Settings.AnimeStandardFormatSearch = true;
++
++            _animeSeasonSearchCriteria.BroadQueriesEmitted = new HashSet<string>();
++
++            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            results.GetTier(0).Should().HaveCount(3);
++            var pages = results.GetTier(0).Select(t => t.First()).ToList();
++            pages[0].Url.FullUri.Should().Contain("q=Monkey%20Island");
++            pages[0].Url.FullUri.Should().NotContain("season=");
++        }
++
++        [Test]
++        public void should_emit_anime_season_broad_query_when_emitted_set_is_null()
++        {
++            Subject.Settings.AnimeStandardFormatSearch = true;
++            _animeSeasonSearchCriteria.BroadQueriesEmitted = null;
++
++            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            results.GetTier(0).Should().HaveCount(3);
++            var pages = results.GetTier(0).Select(t => t.First()).ToList();
++            pages[0].Url.FullUri.Should().Contain("q=Monkey%20Island");
++            pages[0].Url.FullUri.Should().NotContain("season=");
++        }
++
++        [Test]
++        public void should_not_mutate_shared_broad_query_state_for_anime_season_search()
++        {
++            Subject.Settings.AnimeStandardFormatSearch = true;
++
++            var broadEmitted = new HashSet<string> { "Other Title" };
++            _animeSeasonSearchCriteria.BroadQueriesEmitted = broadEmitted;
++
++            Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            broadEmitted.Should().BeEquivalentTo(new[] { "Other Title" });
++        }
++
++        [Test]
++        public void should_use_raw_titles_for_anime_season_broad_query_when_raw_engine()
++        {
++            _capabilities.TextSearchEngine = "raw";
++            _animeSeasonSearchCriteria.SceneTitles = new List<string> { "Edith & Little" };
++
++            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            // Raw engine uses AllSceneTitles (raw + clean variants)
++            var pages = results.GetTier(0).Select(t => t.First()).ToList();
++            pages.Should().HaveCountGreaterOrEqualTo(1);
++
++            // First broad query should use the raw title (& preserved as URL-encoded)
++            pages[0].Url.FullUri.Should().Contain("q=Edith%20%26%20Little");
++        }
++
++        [Test]
++        public void should_use_clean_titles_for_anime_season_broad_query_when_default_engine()
++        {
++            _animeSeasonSearchCriteria.SceneTitles = new List<string> { "Edith & Little" };
++
++            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            results.GetTier(0).Should().HaveCount(1);
++            var page = results.GetTier(0).First().First();
++
++            // Default engine replaces & with "and"
++            page.Url.FullUri.Should().Contain("q=Edith%20and%20Little");
++        }
++
++        [Test]
++        public void should_suppress_clean_broad_query_when_emitted_set_has_raw_title()
++        {
++            // Default engine uses clean titles, but suppression normalizes both ways
++            _animeSeasonSearchCriteria.SceneTitles = new List<string> { "Edith & Little" };
++            _animeSeasonSearchCriteria.BroadQueriesEmitted = new HashSet<string> { "Edith & Little" };
++
++            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            // Broad query should be suppressed via clean-title normalization
++            results.GetTier(0).Should().HaveCount(0);
++        }
++
++        [Test]
++        public void should_suppress_anime_season_broad_query_for_title_with_parens()
++        {
++            _animeSeasonSearchCriteria.SceneTitles = new List<string> { "Title (2020)" };
++            _animeSeasonSearchCriteria.BroadQueriesEmitted = new HashSet<string> { "Title (2020)" };
++
++            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            // Parens are normalized away by GetCleanSceneTitle, suppression matches
++            results.GetTier(0).Should().HaveCount(0);
++        }
++
+         [Test]
+         public void should_not_search_by_rid_if_not_supported()
+         {
+diff --git a/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs b/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs
+index 5ac2bffc38195b8bce150f7a42a5ed29320f7f53..cf6adb3c608970cd586ec8f67ae46588d7d7a371 100644
+--- a/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs
++++ b/src/NzbDrone.Core.Test/IndexerTests/NyaaTests/NyaaRequestGeneratorFixture.cs
+@@ -5,6 +5,7 @@
+ using NzbDrone.Core.Indexers.Nyaa;
+ using NzbDrone.Core.IndexerSearch.Definitions;
+ using NzbDrone.Core.Test.Framework;
++using NzbDrone.Core.Tv;
+ 
+ namespace NzbDrone.Core.Test.IndexerTests.NyaaTests
+ {
+@@ -96,11 +97,220 @@ public void should_search_by_standard_season_number()
+             Subject.Settings.AnimeStandardFormatSearch = true;
+             var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
+ 
+-            results.GetAllTiers().Should().HaveCount(1);
++            results.GetTier(0).Should().HaveCount(2);
+ 
+-            var page = results.GetAllTiers().First().First();
++            var pages = results.GetTier(0).Select(t => t.First()).ToList();
++
++            pages[0].Url.FullUri.Should().Contain("term=Naruto+Shippuuden");
++            pages[0].Url.FullUri.Should().NotContain("+s03");
++            pages[1].Url.FullUri.Should().Contain("term=Naruto+Shippuuden+s03");
++        }
++
++        [Test]
++        public void should_search_broad_title_only_when_standard_format_disabled()
++        {
++            Subject.Settings.AnimeStandardFormatSearch = false;
++            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            results.GetTier(0).Should().HaveCount(1);
++
++            var page = results.GetTier(0).First().First();
++
++            page.Url.FullUri.Should().Contain("term=Naruto+Shippuuden");
++            page.Url.FullUri.Should().NotContain("+s");
++        }
++
++        [Test]
++        public void should_emit_broad_query_per_scene_title()
++        {
++            _animeSeasonSearchCriteria.SceneTitles = new List<string> { "Title One", "Title Two" };
++
++            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            results.GetTier(0).Should().HaveCount(2);
++
++            var pages = results.GetTier(0).Select(t => t.First()).ToList();
++
++            pages[0].Url.FullUri.Should().Contain("term=Title+One");
++            pages[1].Url.FullUri.Should().Contain("term=Title+Two");
++        }
++
++        [Test]
++        public void should_emit_broad_and_standard_queries_per_scene_title()
++        {
++            Subject.Settings.AnimeStandardFormatSearch = true;
++            _animeSeasonSearchCriteria.SceneTitles = new List<string> { "Title One", "Title Two" };
++
++            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            results.GetTier(0).Should().HaveCount(4);
+ 
++            var pages = results.GetTier(0).Select(t => t.First()).ToList();
++
++            pages[0].Url.FullUri.Should().Contain("term=Title+One");
++            pages[0].Url.FullUri.Should().NotContain("+s");
++            pages[1].Url.FullUri.Should().Contain("term=Title+One+s03");
++            pages[2].Url.FullUri.Should().Contain("term=Title+Two");
++            pages[2].Url.FullUri.Should().NotContain("+s");
++            pages[3].Url.FullUri.Should().Contain("term=Title+Two+s03");
++        }
++
++        [Test]
++        public void should_deduplicate_identical_scene_titles()
++        {
++            Subject.Settings.AnimeStandardFormatSearch = true;
++            _animeSeasonSearchCriteria.SceneTitles = new List<string> { "Naruto Shippuuden", "Naruto Shippuuden", "Other Title" };
++
++            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            results.GetTier(0).Should().HaveCount(4);
++
++            var pages = results.GetTier(0).Select(t => t.First()).ToList();
++
++            pages[0].Url.FullUri.Should().Contain("term=Naruto+Shippuuden");
++            pages[0].Url.FullUri.Should().NotContain("+s");
++            pages[1].Url.FullUri.Should().Contain("term=Naruto+Shippuuden+s03");
++            pages[2].Url.FullUri.Should().Contain("term=Other+Title");
++            pages[2].Url.FullUri.Should().NotContain("+s");
++            pages[3].Url.FullUri.Should().Contain("term=Other+Title+s03");
++        }
++
++        [Test]
++        public void should_suppress_broad_query_already_emitted_in_series_search()
++        {
++            Subject.Settings.AnimeStandardFormatSearch = true;
++
++            var broadEmitted = new HashSet<string> { "Naruto Shippuuden" };
++
++            _animeSeasonSearchCriteria.BroadQueriesEmitted = broadEmitted;
++
++            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            // Should only have the season-specific query, not the broad title-only one
++            results.GetTier(0).Should().HaveCount(1);
++
++            var page = results.GetTier(0).First().First();
+             page.Url.FullUri.Should().Contain("term=Naruto+Shippuuden+s03");
+         }
++
++        [Test]
++        public void should_emit_broad_query_when_not_yet_in_emitted_set()
++        {
++            Subject.Settings.AnimeStandardFormatSearch = true;
++
++            var broadEmitted = new HashSet<string>();
++            _animeSeasonSearchCriteria.BroadQueriesEmitted = broadEmitted;
++
++            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            // Should have both broad and season-specific queries
++            results.GetTier(0).Should().HaveCount(2);
++            broadEmitted.Should().BeEmpty();
++        }
++
++        [Test]
++        public void should_still_emit_broad_query_when_no_emitted_set_provided()
++        {
++            Subject.Settings.AnimeStandardFormatSearch = true;
++            _animeSeasonSearchCriteria.BroadQueriesEmitted = null;
++
++            var results = Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            results.GetTier(0).Should().HaveCount(2);
++
++            var pages = results.GetTier(0).Select(t => t.First()).ToList();
++            pages[0].Url.FullUri.Should().Contain("term=Naruto+Shippuuden");
++            pages[0].Url.FullUri.Should().NotContain("+s");
++        }
++
++        [Test]
++        public void should_not_mutate_shared_broad_query_state()
++        {
++            Subject.Settings.AnimeStandardFormatSearch = true;
++
++            var broadEmitted = new HashSet<string> { "Other Title" };
++            _animeSeasonSearchCriteria.BroadQueriesEmitted = broadEmitted;
++
++            Subject.GetSearchRequests(_animeSeasonSearchCriteria);
++
++            broadEmitted.Should().BeEquivalentTo(new[] { "Other Title" });
++        }
++
++        [Test]
++        public void should_emit_s00e01_for_single_episode_search_with_season_0()
++        {
++            Subject.Settings.AnimeStandardFormatSearch = true;
++
++            var criteria = new SingleEpisodeSearchCriteria
++            {
++                SceneTitles = new List<string> { "Grimgar" },
++                SeasonNumber = 0,
++                EpisodeNumber = 1
++            };
++
++            var results = Subject.GetSearchRequests(criteria);
++
++            results.GetTier(0).Should().HaveCount(1);
++
++            var page = results.GetTier(0).First().First();
++            page.Url.FullUri.Should().Contain("term=Grimgar+s00e01");
++        }
++
++        [Test]
++        public void should_not_emit_s00e01_when_standard_format_search_disabled()
++        {
++            Subject.Settings.AnimeStandardFormatSearch = false;
++
++            var criteria = new SingleEpisodeSearchCriteria
++            {
++                SceneTitles = new List<string> { "Grimgar" },
++                SeasonNumber = 0,
++                EpisodeNumber = 1
++            };
++
++            var results = Subject.GetSearchRequests(criteria);
++
++            results.GetAllTiers().Should().HaveCount(0);
++        }
++
++        [Test]
++        public void should_emit_anime_special_alias_queries_for_anime_series()
++        {
++            var criteria = new SpecialEpisodeSearchCriteria
++            {
++                Series = new Series { SeriesType = SeriesTypes.Anime },
++                SceneTitles = new List<string> { "Grimgar" },
++                EpisodeQueryTitles = new[] { "Grimgar OVA 2.5" }
++            };
++
++            var results = Subject.GetSearchRequests(criteria);
++            var pages = results.GetAllTiers().Select(t => t.First()).ToList();
++
++            // 1 episode-title query + 4 alias queries (ova, oav, special, specials)
++            pages.Should().HaveCount(5);
++            pages[0].Url.FullUri.Should().Contain("term=Grimgar+OVA+2.5");
++            pages[1].Url.FullUri.Should().Contain("term=Grimgar+ova");
++            pages[2].Url.FullUri.Should().Contain("term=Grimgar+oav");
++            pages[3].Url.FullUri.Should().Contain("term=Grimgar+special");
++            pages[4].Url.FullUri.Should().Contain("term=Grimgar+specials");
++        }
++
++        [Test]
++        public void should_not_emit_anime_special_alias_queries_for_non_anime_series()
++        {
++            var criteria = new SpecialEpisodeSearchCriteria
++            {
++                Series = new Series { SeriesType = SeriesTypes.Standard },
++                SceneTitles = new List<string> { "Some Show" },
++                EpisodeQueryTitles = new[] { "Some Show Special Episode" }
++            };
++
++            var results = Subject.GetSearchRequests(criteria);
++            var pages = results.GetAllTiers().Select(t => t.First()).ToList();
++
++            // Only the episode-title query, no alias queries
++            pages.Should().HaveCount(1);
++            pages[0].Url.FullUri.Should().Contain("term=Some+Show+Special+Episode");
++        }
+     }
+ }
+diff --git a/src/NzbDrone.Core.Test/ParserTests/AbsoluteEpisodeNumberParserFixture.cs b/src/NzbDrone.Core.Test/ParserTests/AbsoluteEpisodeNumberParserFixture.cs
+index 13fd2f60dd07c0e9093b1ffd8f1f739c80df8c7b..3e30c5740cec68d1754bf04b9106f4a210bff73e 100644
+--- a/src/NzbDrone.Core.Test/ParserTests/AbsoluteEpisodeNumberParserFixture.cs
++++ b/src/NzbDrone.Core.Test/ParserTests/AbsoluteEpisodeNumberParserFixture.cs
+@@ -40,6 +40,8 @@ public class AbsoluteEpisodeNumberParserFixture : CoreTest
+         [TestCase("[DeadFish] Series Title - 09v2 [720p][AAC]", "Series Title", 9, 0, 0)]
+         [TestCase("[Underwater-FFF] Series Title - 01 (720p) [27AAA0A0]", "Series Title", 1, 0, 0)]
+         [TestCase("[S-T-D] Series Title! - 06 (1280x720 10bit AAC) [59B3F2EA].mkv", "Series Title!", 6, 0, 0)]
++        [TestCase("[S-T-D] Series Title! - 06 (1280x720 10 bit AAC) [59B3F2EA].mkv", "Series Title!", 6, 0, 0)]
++        [TestCase("[HorribleSubs] Series Title - 09 [720p 8 bits] [ABCDEF12]", "Series Title", 9, 0, 0)]
+         [TestCase("Series Title - 010 (720p) [27AAA0A0].mkv", "Series Title", 10, 0, 0)]
+         [TestCase("Initial_Series_Title - 01 DVD - Central Anime", "Initial Series Title", 1, 0, 0)]
+         [TestCase("Initial_Series_Title_-_01(DVD)_-_(Central_Anime)[5AF6F1E4].mkv", "Initial Series Title", 1, 0, 0)]
+@@ -167,6 +169,7 @@ public void should_parse_absolute_specials(string postTitle, string title, int a
+             result.Special.Should().BeTrue();
+         }
+ 
++        [TestCase("[Arigatou] El Cazador de la Bruja 1-26 [x264.AAC].mkv", "El Cazador de la Bruja", 1, 26)]
+         [TestCase("[ANBU-AonE]_SeriesTitle_26-27_[F224EF26].avi", "SeriesTitle", 26, 27)]
+         [TestCase("[Doutei] Some Good, Anime Show - 01-12 [BD][720p-AAC]", "Some Good, Anime Show", 1, 12)]
+         [TestCase("Series Title (2010) - 01-02-03 - Episode Title (1) HDTV-720p", "Series Title (2010)", 1, 3)]
+@@ -202,6 +205,7 @@ public void should_parse_multi_episode_absolute_numbers(string postTitle, string
+         [TestCase("Anime, Title? | Japanse Anime, Title? [Season 1 + EXTRA] [BD 1080p x265 HEVC OPUS] [Dual-Audio]", "Anime, Title | Japanse Anime, Title", 1)]
+         [TestCase("[Judas] Japanse Anime, Title (Anime, Title?) (Season 1) [1080p][HEVC x265 10bit][Multi-Subs] (Batch)", "Japanse Anime, Title (Anime, Title)", 1)]
+         [TestCase("[Judas] Japanse Anime, Title (Anime, Title?) (Season 1) [1080p][HEVC x265 10bit][Multi-Subs] (Batch)", "Japanse Anime, Title (Anime, Title)", 1)]
++        [TestCase("[EMBER] Grimgar: Ashes and Illusions (2016) (Season 1) [BDRip] [1080p Dual Audio HEVC 10 bits] (Hai to Gensou no Grimgar)", "Grimgar: Ashes and Illusions (2016)", 1)]
+         public void should_parse_anime_season_packs(string postTitle, string title, int seasonNumber)
+         {
+             var result = Parser.Parser.ParseTitle(postTitle);
+diff --git a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetEpisodesFixture.cs b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetEpisodesFixture.cs
+index 9a5610838043a2bc5c1f4b9707e25e6f82c50533..d32f2e16a7ce667d7b0049b1fa997ea6d2ffe32d 100644
+--- a/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetEpisodesFixture.cs
++++ b/src/NzbDrone.Core.Test/ParserTests/ParsingServiceTests/GetEpisodesFixture.cs
+@@ -521,6 +521,174 @@ public void should_fallback_to_lookup_full_season_by_season_number_if_series_use
+                 .Verify(v => v.GetEpisodesBySceneSeason(It.IsAny<int>(), It.IsAny<int>()), Times.Once);
+         }
+ 
++        [Test]
++        public void should_lookup_anime_multi_season_by_scene_season_number_if_series_uses_scene_numbering()
++        {
++            GivenSceneNumberingSeries();
++            GivenFullSeason();
++            _series.SeriesType = SeriesTypes.Anime;
++            _parsedEpisodeInfo.IsMultiSeason = true;
++            _parsedEpisodeInfo.SeasonNumbers = new[] { 1, 2 };
++
++            var season1Episodes = new List<Episode>
++            {
++                Builder<Episode>.CreateNew()
++                    .With(e => e.Id = 101)
++                    .With(e => e.SeasonNumber = 1)
++                    .Build()
++            };
++            var season2Episodes = new List<Episode>
++            {
++                Builder<Episode>.CreateNew()
++                    .With(e => e.Id = 202)
++                    .With(e => e.SeasonNumber = 2)
++                    .Build()
++            };
++
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySceneSeason(_series.Id, 1))
++                .Returns(season1Episodes);
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySceneSeason(_series.Id, 2))
++                .Returns(season2Episodes);
++
++            var result = Subject.GetEpisodes(_parsedEpisodeInfo, _series, true, null);
++
++            result.Select(e => e.Id).Should().BeEquivalentTo(new[] { 101, 202 });
++            Mocker.GetMock<IEpisodeService>()
++                .Verify(v => v.GetEpisodesBySceneSeason(_series.Id, 1), Times.Once);
++            Mocker.GetMock<IEpisodeService>()
++                .Verify(v => v.GetEpisodesBySceneSeason(_series.Id, 2), Times.Once);
++            Mocker.GetMock<IEpisodeService>()
++                .Verify(v => v.GetEpisodesBySeason(It.IsAny<int>(), It.IsAny<int>()), Times.Never);
++        }
++
++        [Test]
++        public void should_fallback_to_tvdb_season_for_anime_multi_season_when_scene_lookup_is_empty()
++        {
++            GivenSceneNumberingSeries();
++            GivenFullSeason();
++            _series.SeriesType = SeriesTypes.Anime;
++            _parsedEpisodeInfo.IsMultiSeason = true;
++            _parsedEpisodeInfo.SeasonNumbers = new[] { 1, 2 };
++
++            var season2Episodes = new List<Episode>
++            {
++                Builder<Episode>.CreateNew()
++                    .With(e => e.Id = 202)
++                    .With(e => e.SeasonNumber = 2)
++                    .Build()
++            };
++
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySceneSeason(_series.Id, 1))
++                .Returns(new List<Episode>());
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySceneSeason(_series.Id, 2))
++                .Returns(season2Episodes);
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 1))
++                .Returns(new List<Episode>
++                {
++                    Builder<Episode>.CreateNew()
++                        .With(e => e.Id = 101)
++                        .With(e => e.SeasonNumber = 1)
++                        .Build()
++                });
++
++            var result = Subject.GetEpisodes(_parsedEpisodeInfo, _series, true, null);
++
++            result.Select(e => e.Id).Should().BeEquivalentTo(new[] { 101, 202 });
++            Mocker.GetMock<IEpisodeService>()
++                .Verify(v => v.GetEpisodesBySeason(_series.Id, 1), Times.Once);
++        }
++
++        [Test]
++        public void should_return_episodes_for_anime_multi_season_pack_with_specials_metadata()
++        {
++            _series.SeriesType = SeriesTypes.Anime;
++
++            // Simulates a parsed anime multi-season pack whose trailing metadata
++            // contains "Specials" (e.g. [Anime Time] SAO (S01+S02+S03+S04+Movies+Specials+OVAs)).
++            // With the parser fix, FullSeason stays true and Special stays false.
++            _parsedEpisodeInfo.FullSeason = true;
++            _parsedEpisodeInfo.IsMultiSeason = true;
++            _parsedEpisodeInfo.Special = false;
++            _parsedEpisodeInfo.SeasonNumber = 1;
++            _parsedEpisodeInfo.SeasonNumbers = new[] { 1, 2 };
++            _parsedEpisodeInfo.EpisodeNumbers = Array.Empty<int>();
++
++            var season1Episodes = new List<Episode>
++            {
++                Builder<Episode>.CreateNew()
++                    .With(e => e.Id = 101)
++                    .With(e => e.SeasonNumber = 1)
++                    .Build()
++            };
++            var season2Episodes = new List<Episode>
++            {
++                Builder<Episode>.CreateNew()
++                    .With(e => e.Id = 202)
++                    .With(e => e.SeasonNumber = 2)
++                    .Build()
++            };
++
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 1))
++                .Returns(season1Episodes);
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 2))
++                .Returns(season2Episodes);
++
++            var result = Subject.GetEpisodes(_parsedEpisodeInfo, _series, false, null);
++
++            result.Should().HaveCount(2);
++            result.Select(e => e.Id).Should().BeEquivalentTo(new[] { 101, 202 });
++        }
++
++        [Test]
++        public void should_map_real_anime_multi_season_title_with_specials_metadata()
++        {
++            _series.SeriesType = SeriesTypes.Anime;
++
++            var parsedEpisodeInfo = Parser.Parser.ParseTitle("[Anime Time] Sword Art Online (S01+S02+S03+S04+Movies+Specials+OVAs) [BD][1080p][HEVC 10bit x265][AAC][Eng Sub]");
++
++            parsedEpisodeInfo.Should().NotBeNull();
++            parsedEpisodeInfo.FullSeason.Should().BeTrue();
++            parsedEpisodeInfo.Special.Should().BeFalse();
++            parsedEpisodeInfo.IsMultiSeason.Should().BeTrue();
++            parsedEpisodeInfo.SeasonNumbers.Should().BeEquivalentTo(new[] { 1, 2, 3, 4 });
++
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 1))
++                .Returns(new List<Episode>
++                {
++                    Builder<Episode>.CreateNew().With(e => e.Id = 101).With(e => e.SeasonNumber = 1).Build()
++                });
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 2))
++                .Returns(new List<Episode>
++                {
++                    Builder<Episode>.CreateNew().With(e => e.Id = 202).With(e => e.SeasonNumber = 2).Build()
++                });
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 3))
++                .Returns(new List<Episode>
++                {
++                    Builder<Episode>.CreateNew().With(e => e.Id = 303).With(e => e.SeasonNumber = 3).Build()
++                });
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 4))
++                .Returns(new List<Episode>
++                {
++                    Builder<Episode>.CreateNew().With(e => e.Id = 404).With(e => e.SeasonNumber = 4).Build()
++                });
++
++            var remoteEpisode = Subject.Map(parsedEpisodeInfo, _series);
++
++            remoteEpisode.Episodes.Select(e => e.Id).Should().BeEquivalentTo(new[] { 101, 202, 303, 404 });
++        }
++
+         [Test]
+         public void should_use_season_zero_when_looking_up_is_partial_special_episode_found_by_title()
+         {
+@@ -560,5 +728,195 @@ public void should_use_original_parse_result_when_special_episode_lookup_by_titl
+             Mocker.GetMock<IEpisodeService>()
+                   .Verify(v => v.FindEpisode(_series.TvdbId, _parsedEpisodeInfo.SeasonNumber, _parsedEpisodeInfo.EpisodeNumbers.First()), Times.Once());
+         }
++
++        [Test]
++        public void should_cocover_single_wanted_season0_special_for_anime_pack_with_special_keyword()
++        {
++            _series.SeriesType = SeriesTypes.Anime;
++            _parsedEpisodeInfo.FullSeason = true;
++            _parsedEpisodeInfo.EpisodeNumbers = Array.Empty<int>();
++            _parsedEpisodeInfo.SeasonNumber = 1;
++            _parsedEpisodeInfo.ReleaseTitle = "[SubGroup] Grimgar S01+Specials [1080p]";
++
++            var season1Episodes = new List<Episode>
++            {
++                Builder<Episode>.CreateNew()
++                    .With(e => e.Id = 101)
++                    .With(e => e.SeasonNumber = 1)
++                    .Build()
++            };
++
++            var season0Special = Builder<Episode>.CreateNew()
++                .With(e => e.Id = 901)
++                .With(e => e.SeasonNumber = 0)
++                .With(e => e.Monitored = true)
++                .With(e => e.EpisodeFileId = 0)
++                .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(-30))
++                .Build();
++
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 1))
++                .Returns(season1Episodes);
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 0))
++                .Returns(new List<Episode> { season0Special });
++
++            var result = Subject.GetEpisodes(_parsedEpisodeInfo, _series, false, null);
++
++            result.Should().HaveCount(2);
++            result.Select(e => e.Id).Should().BeEquivalentTo(new[] { 101, 901 });
++        }
++
++        [TestCase("[SubGroup] Grimgar S01+OVA [1080p]")]
++        [TestCase("[SubGroup] Grimgar S01+OAV [1080p]")]
++        [TestCase("[SubGroup] Grimgar S01+Special [1080p]")]
++        [TestCase("[Trix] Grimgar: Ashes and Illusions S01+OVA (Batch) [BDRip 1080p AV1 Opus] (Dual Audio, Multi Subs, VOSTFR) | Hai to Gensou no Grimgar 灰と幻想のグリムガル Season S1 OAV Specials")]
++        public void should_cocover_single_wanted_season0_special_for_anime_pack_with_ova_keyword(string releaseTitle)
++        {
++            _series.SeriesType = SeriesTypes.Anime;
++            _parsedEpisodeInfo.FullSeason = true;
++            _parsedEpisodeInfo.EpisodeNumbers = Array.Empty<int>();
++            _parsedEpisodeInfo.SeasonNumber = 1;
++            _parsedEpisodeInfo.ReleaseTitle = releaseTitle;
++
++            var season1Episodes = new List<Episode>
++            {
++                Builder<Episode>.CreateNew()
++                    .With(e => e.Id = 101)
++                    .With(e => e.SeasonNumber = 1)
++                    .Build()
++            };
++
++            var season0Special = Builder<Episode>.CreateNew()
++                .With(e => e.Id = 901)
++                .With(e => e.SeasonNumber = 0)
++                .With(e => e.Monitored = true)
++                .With(e => e.EpisodeFileId = 0)
++                .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(-30))
++                .Build();
++
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 1))
++                .Returns(season1Episodes);
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 0))
++                .Returns(new List<Episode> { season0Special });
++
++            var result = Subject.GetEpisodes(_parsedEpisodeInfo, _series, false, null);
++
++            result.Should().HaveCount(2);
++            result.Select(e => e.Id).Should().BeEquivalentTo(new[] { 101, 901 });
++        }
++
++        [Test]
++        public void should_not_cocover_season0_when_multiple_wanted_specials()
++        {
++            _series.SeriesType = SeriesTypes.Anime;
++            _parsedEpisodeInfo.FullSeason = true;
++            _parsedEpisodeInfo.EpisodeNumbers = Array.Empty<int>();
++            _parsedEpisodeInfo.SeasonNumber = 1;
++            _parsedEpisodeInfo.ReleaseTitle = "[SubGroup] Grimgar S01+Specials [1080p]";
++
++            var season1Episodes = new List<Episode>
++            {
++                Builder<Episode>.CreateNew()
++                    .With(e => e.Id = 101)
++                    .With(e => e.SeasonNumber = 1)
++                    .Build()
++            };
++
++            var season0Specials = new List<Episode>
++            {
++                Builder<Episode>.CreateNew()
++                    .With(e => e.Id = 901)
++                    .With(e => e.SeasonNumber = 0)
++                    .With(e => e.Monitored = true)
++                    .With(e => e.EpisodeFileId = 0)
++                    .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(-30))
++                    .Build(),
++                Builder<Episode>.CreateNew()
++                    .With(e => e.Id = 902)
++                    .With(e => e.SeasonNumber = 0)
++                    .With(e => e.Monitored = true)
++                    .With(e => e.EpisodeFileId = 0)
++                    .With(e => e.AirDateUtc = DateTime.UtcNow.AddDays(-20))
++                    .Build()
++            };
++
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 1))
++                .Returns(season1Episodes);
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 0))
++                .Returns(season0Specials);
++
++            var result = Subject.GetEpisodes(_parsedEpisodeInfo, _series, false, null);
++
++            result.Should().HaveCount(1);
++            result.Select(e => e.Id).Should().BeEquivalentTo(new[] { 101 });
++        }
++
++        [TestCase("[SubGroup] Grimgar S01+Extras [1080p]")]
++        [TestCase("[SubGroup] Grimgar S01+NCOP [1080p]")]
++        [TestCase("[SubGroup] Grimgar S01+NCED [1080p]")]
++        [TestCase("[SubGroup] Grimgar S01+Menu [1080p]")]
++        [TestCase("[SubGroup] Grimgar S01+Bonus [1080p]")]
++        public void should_not_cocover_season0_when_title_has_non_episode_markers(string releaseTitle)
++        {
++            _series.SeriesType = SeriesTypes.Anime;
++            _parsedEpisodeInfo.FullSeason = true;
++            _parsedEpisodeInfo.EpisodeNumbers = Array.Empty<int>();
++            _parsedEpisodeInfo.SeasonNumber = 1;
++            _parsedEpisodeInfo.ReleaseTitle = releaseTitle;
++
++            var season1Episodes = new List<Episode>
++            {
++                Builder<Episode>.CreateNew()
++                    .With(e => e.Id = 101)
++                    .With(e => e.SeasonNumber = 1)
++                    .Build()
++            };
++
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 1))
++                .Returns(season1Episodes);
++
++            var result = Subject.GetEpisodes(_parsedEpisodeInfo, _series, false, null);
++
++            result.Should().HaveCount(1);
++            result.Select(e => e.Id).Should().BeEquivalentTo(new[] { 101 });
++
++            // Should NOT query season 0 episodes at all
++            Mocker.GetMock<IEpisodeService>()
++                .Verify(v => v.GetEpisodesBySeason(_series.Id, 0), Times.Never);
++        }
++
++        [Test]
++        public void should_not_cocover_season0_for_standard_series()
++        {
++            _series.SeriesType = SeriesTypes.Standard;
++            _parsedEpisodeInfo.FullSeason = true;
++            _parsedEpisodeInfo.EpisodeNumbers = Array.Empty<int>();
++            _parsedEpisodeInfo.SeasonNumber = 1;
++            _parsedEpisodeInfo.ReleaseTitle = "Series Title S01+Specials 1080p";
++
++            var season1Episodes = new List<Episode>
++            {
++                Builder<Episode>.CreateNew()
++                    .With(e => e.Id = 101)
++                    .With(e => e.SeasonNumber = 1)
++                    .Build()
++            };
++
++            Mocker.GetMock<IEpisodeService>()
++                .Setup(s => s.GetEpisodesBySeason(_series.Id, 1))
++                .Returns(season1Episodes);
++
++            var result = Subject.GetEpisodes(_parsedEpisodeInfo, _series, false, null);
++
++            result.Should().HaveCount(1);
++            Mocker.GetMock<IEpisodeService>()
++                .Verify(v => v.GetEpisodesBySeason(_series.Id, 0), Times.Never);
++        }
+     }
+ }
+diff --git a/src/NzbDrone.Core.Test/ParserTests/SeasonParserFixture.cs b/src/NzbDrone.Core.Test/ParserTests/SeasonParserFixture.cs
+old mode 100644
+new mode 100755
+index f7838bebfac522b359e5e6de8f59ce746fd4407a..fc9a3b12354ac60c39d455bab16344e51ffcc983
+--- a/src/NzbDrone.Core.Test/ParserTests/SeasonParserFixture.cs
++++ b/src/NzbDrone.Core.Test/ParserTests/SeasonParserFixture.cs
+@@ -1,3 +1,4 @@
++using System.Linq;
+ using FluentAssertions;
+ using NUnit.Framework;
+ using NzbDrone.Core.Test.Framework;
+@@ -37,6 +38,7 @@ public class SeasonParserFixture : CoreTest
+         [TestCase("[HorribleRips] Mobile Series 00 S1 [1080p]", "Mobile Series 00", 1)]
+         [TestCase("[Zoombie] Series 100: Bucket List S01 [Web][MKV][h265 10-bit][1080p][AC3 2.0][Softsubs (Zoombie)]", "Series 100: Bucket List", 1)]
+         [TestCase("Seriesless (2016/S01/WEB-DL/1080p/AC3 5.1/DUAL/SUB)", "Seriesless (2016)", 1)]
++        [TestCase("Series Title S01 (1080p BluRay x265 HEVC 10 bits AAC 5.1 Tigole)", "Series Title", 1)]
+         public void should_parse_full_season_release(string postTitle, string title, int season)
+         {
+             var result = Parser.Parser.ParseTitle(postTitle);
+@@ -112,6 +114,114 @@ public void should_parse_multi_season_release(string postTitle, string title, in
+             result.IsMultiSeason.Should().BeTrue();
+         }
+ 
++        [TestCase("[SubGroup] Sword Art Online S01-S04 1080p BluRay x264", "Sword Art Online", 1, new[] { 1, 2, 3, 4 })]
++        [TestCase("[SubGroup] Sword Art Online S01-S02 1080p BluRay", "Sword Art Online", 1, new[] { 1, 2 })]
++        [TestCase("[Reaktor] Attack on Titan S01-S03 BD 1080p", "Attack on Titan", 1, new[] { 1, 2, 3 })]
++        public void should_parse_anime_multi_season_range(string postTitle, string title, int firstSeason, int[] expectedSeasons)
++        {
++            var result = Parser.Parser.ParseTitle(postTitle);
++            result.SeriesTitle.Should().Be(title);
++            result.SeasonNumber.Should().Be(firstSeason);
++            result.FullSeason.Should().BeTrue();
++            result.IsMultiSeason.Should().BeTrue();
++            result.SeasonNumbers.Should().BeEquivalentTo(expectedSeasons);
++        }
++
++        [TestCase("[SubGroup] Sword Art Online S01+S02+S03+S04 1080p BluRay", "Sword Art Online", 1, new[] { 1, 2, 3, 4 })]
++        [TestCase("[SubGroup] Title S01+S03 1080p", "Title", 1, new[] { 1, 3 })]
++        [TestCase("[Tenrai-Sensei] Sword Art Online S1+S2+S3+S4+The Movie+OVAs", "Sword Art Online", 1, new[] { 1, 2, 3, 4 })]
++        [TestCase("[Anime Time] Sword Art Online (S01+S02+S03+S04+...)", "Sword Art Online", 1, new[] { 1, 2, 3, 4 })]
++        [TestCase("[Kosaka] Sword Art Online (S01+S02+S03+S04+...)", "Sword Art Online", 1, new[] { 1, 2, 3, 4 })]
++        public void should_parse_anime_multi_season_list(string postTitle, string title, int firstSeason, int[] expectedSeasons)
++        {
++            var result = Parser.Parser.ParseTitle(postTitle);
++            result.SeriesTitle.Should().Be(title);
++            result.SeasonNumber.Should().Be(firstSeason);
++            result.FullSeason.Should().BeTrue();
++            result.IsMultiSeason.Should().BeTrue();
++            result.SeasonNumbers.Should().BeEquivalentTo(expectedSeasons);
++        }
++
++        [TestCase("[Anime Time] Sword Art Online (S01+S02+S03+S04+Movies+Specials+OVAs) [BD][1080p][HEVC 10bit x265][AAC][Eng Sub]", "Sword Art Online", 1, new[] { 1, 2, 3, 4 })]
++        [TestCase("[Kosaka] Sword Art Online (S01+S02+S03+S04+Movies+Specials+OVAs) [BD 1080p HEVC x265 10bit][Dual Audio][Multi Subs]", "Sword Art Online", 1, new[] { 1, 2, 3, 4 })]
++        [TestCase("[Tenrai-Sensei] Sword Art Online S1+S2+S3+S4+The Movie+OVAs [BD 1080p]", "Sword Art Online", 1, new[] { 1, 2, 3, 4 })]
++        [TestCase("[AceAres] Sword Art Online S01+S02+S03+S04 + Movie + Special [BD 1080p HEVC x265]", "Sword Art Online", 1, new[] { 1, 2, 3, 4 })]
++        public void should_parse_anime_multi_season_with_specials_metadata(string postTitle, string title, int firstSeason, int[] expectedSeasons)
++        {
++            var result = Parser.Parser.ParseTitle(postTitle);
++            result.Should().NotBeNull();
++            result.SeriesTitle.Should().Be(title);
++            result.SeasonNumber.Should().Be(firstSeason);
++            result.IsMultiSeason.Should().BeTrue();
++            result.FullSeason.Should().BeTrue();
++            result.Special.Should().BeFalse();
++            result.SeasonNumbers.Should().BeEquivalentTo(expectedSeasons);
++        }
++
++        [TestCase("[SubGroup] Sword Art Online S01 1080p BluRay x264")]
++        [TestCase("[HorribleRips] Mobile Suit Gundam 00 S1 [1080p]")]
++        public void should_not_parse_anime_single_season_as_multi(string postTitle)
++        {
++            var result = Parser.Parser.ParseTitle(postTitle);
++            result.Should().NotBeNull();
++            result.FullSeason.Should().BeTrue();
++            result.IsMultiSeason.Should().BeFalse();
++        }
++
++        [TestCase("Series Title S03 Specials DVDRip XviD RUNNER", "Series Title", 3)]
++        [TestCase("Series Title S05 Special 720p HDTV", "Series Title", 5)]
++        public void should_downgrade_single_season_special_to_special(string postTitle, string title, int season)
++        {
++            var result = Parser.Parser.ParseTitle(postTitle);
++            result.Should().NotBeNull();
++            result.SeriesTitle.Should().Be(title);
++            result.SeasonNumber.Should().Be(season);
++            result.FullSeason.Should().BeFalse();
++            result.Special.Should().BeTrue();
++            result.IsMultiSeason.Should().BeFalse();
++        }
++
++        [TestCase("[SubGroup] Title S01+S02+")]
++        [TestCase("[SubGroup] Title S01+S02+Sx")]
++        [TestCase("[SubGroup] Title S01+S02+1")]
++        public void should_not_parse_malformed_anime_multi_season_tail(string postTitle)
++        {
++            var result = Parser.Parser.ParseTitle(postTitle);
++
++            // May parse as single-season via another regex, or fail entirely;
++            // either way it must not be detected as a multi-season pack
++            if (result != null)
++            {
++                result.IsMultiSeason.Should().BeFalse();
++            }
++        }
++
++        [Test]
++        public void should_populate_season_numbers_for_standard_multi_season()
++        {
++            var result = Parser.Parser.ParseTitle("Series.Title.S01-S09.1080p.AMZN.WEB-DL.DDP2.0.H.264-NTb");
++            result.IsMultiSeason.Should().BeTrue();
++            result.SeasonNumbers.Should().BeEquivalentTo(Enumerable.Range(1, 9));
++        }
++
++        [TestCase("[SubGroup] Grimgar S01+Specials [1080p]", "Grimgar", 1)]
++        [TestCase("[SubGroup] Grimgar S01+Special [1080p]", "Grimgar", 1)]
++        [TestCase("[SubGroup] Grimgar S01+OVA [1080p]", "Grimgar", 1)]
++        [TestCase("[SubGroup] Grimgar S01+OAV [1080p]", "Grimgar", 1)]
++        [TestCase("[SubGroup] Grimgar S01 + OVA [1080p]", "Grimgar", 1)]
++        [TestCase("[SubGroup] Grimgar S01 + Specials [1080p]", "Grimgar", 1)]
++        [TestCase("[Trix] Grimgar: Ashes and Illusions S01+OVA (Batch) [BDRip 1080p AV1 Opus] (Dual Audio, Multi Subs, VOSTFR) | Hai to Gensou no Grimgar 灰と幻想のグリムガル Season S1 OAV Specials", "Grimgar: Ashes and Illusions", 1)]
++        public void should_parse_anime_season_plus_specials_as_full_season(string postTitle, string title, int season)
++        {
++            var result = Parser.Parser.ParseTitle(postTitle);
++            result.Should().NotBeNull();
++            result.SeriesTitle.Should().Be(title);
++            result.SeasonNumber.Should().Be(season);
++            result.FullSeason.Should().BeTrue();
++            result.Special.Should().BeFalse();
++            result.IsMultiSeason.Should().BeFalse();
++        }
++
+         [Test]
+         public void should_not_parse_season_folders()
+         {
+diff --git a/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs b/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
+index 14d0afef11c28dc2f2e6006dad23f56a15f71d33..87e926107495e8fee5f03878aa1b8392be77b400 100644
+--- a/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
++++ b/src/NzbDrone.Core.Test/ParserTests/SingleEpisodeParserFixture.cs
+@@ -178,6 +178,8 @@ public class SingleEpisodeParserFixture : CoreTest
+         [TestCase("Amazing Title (2024/S01E07/DSNP/WEB-DL/1080p/ESP/EAC3 5.1/ING/EAC3 5.1 Atmos/SUBS) SPWEB", "Amazing Title (2024)", 1, 7)]
+         [TestCase("Mini Title (Miniserie) (2024/S01E07/DSNP/WEB-DL/1080p/ESP/EAC3 5.1/ING/EAC3 5.1 Atmos/SUBS) SPWEB", "Mini Title (2024)", 1, 7)]
+ 
++        [TestCase("8 Bit Show S01E05 720p HDTV x264-DIMENSION", "8 Bit Show", 1, 5)]
++
+         // [TestCase("", "", 0, 0)]
+         public void should_parse_single_episode(string postTitle, string title, int seasonNumber, int episodeNumber)
+         {
+diff --git a/src/NzbDrone.Core.Test/Sonarr.Core.Test.csproj b/src/NzbDrone.Core.Test/Sonarr.Core.Test.csproj
+index 6a1477da42addf48d29c827fa2bba613042f382b..4d510b27e716051c2f91fe887d77cfe3c5aa8bb5 100644
+--- a/src/NzbDrone.Core.Test/Sonarr.Core.Test.csproj
++++ b/src/NzbDrone.Core.Test/Sonarr.Core.Test.csproj
+@@ -4,7 +4,6 @@
+   </PropertyGroup>
+   <ItemGroup>
+     <PackageReference Include="Dapper" Version="2.0.123" />
+-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+     <PackageReference Include="NBuilder" Version="6.1.0" />
+     <PackageReference Include="System.Data.SQLite.Core.Servarr" Version="1.0.115.5-18" />
+   </ItemGroup>
+diff --git a/src/NzbDrone.Host.Test/Sonarr.Host.Test.csproj b/src/NzbDrone.Host.Test/Sonarr.Host.Test.csproj
+index 00783be18b005f6db75f305fe7e3fe58cd7f436c..e92dc5c401f99b9795150a6df3c39dc7f2f1d08f 100644
+--- a/src/NzbDrone.Host.Test/Sonarr.Host.Test.csproj
++++ b/src/NzbDrone.Host.Test/Sonarr.Host.Test.csproj
+@@ -3,7 +3,6 @@
+     <TargetFrameworks>net6.0</TargetFrameworks>
+   </PropertyGroup>
+   <ItemGroup>
+-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+   </ItemGroup>
+   <ItemGroup>
+     <ProjectReference Include="..\NzbDrone.Host\Sonarr.Host.csproj" />
+diff --git a/src/NzbDrone.Integration.Test/Sonarr.Integration.Test.csproj b/src/NzbDrone.Integration.Test/Sonarr.Integration.Test.csproj
+index b782538804ff46887b8f9445a2f1197c389102c9..79c5960972f844e0d47dd44295324bc17dae9b61 100644
+--- a/src/NzbDrone.Integration.Test/Sonarr.Integration.Test.csproj
++++ b/src/NzbDrone.Integration.Test/Sonarr.Integration.Test.csproj
+@@ -4,7 +4,6 @@
+     <OutputType>Library</OutputType>
+   </PropertyGroup>
+   <ItemGroup>
+-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.21" />
+   </ItemGroup>
+   <ItemGroup>
+diff --git a/src/NzbDrone.Libraries.Test/Sonarr.Libraries.Test.csproj b/src/NzbDrone.Libraries.Test/Sonarr.Libraries.Test.csproj
+index 511c54cba40593f9f2404e663f2320ef94b8da58..ca02b5e9d51109b5b84041019753d60a19543173 100644
+--- a/src/NzbDrone.Libraries.Test/Sonarr.Libraries.Test.csproj
++++ b/src/NzbDrone.Libraries.Test/Sonarr.Libraries.Test.csproj
+@@ -3,7 +3,6 @@
+     <TargetFrameworks>net6.0</TargetFrameworks>
+   </PropertyGroup>
+   <ItemGroup>
+-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+   </ItemGroup>
+   <ItemGroup>
+     <ProjectReference Include="..\NzbDrone.Test.Common\Sonarr.Test.Common.csproj" />
+diff --git a/src/NzbDrone.Mono.Test/Sonarr.Mono.Test.csproj b/src/NzbDrone.Mono.Test/Sonarr.Mono.Test.csproj
+index 60c6f901cd9a795d8c2572857cf0b602679be8a1..2660db2e4834606458cb1c25e96e02ece2102b9b 100644
+--- a/src/NzbDrone.Mono.Test/Sonarr.Mono.Test.csproj
++++ b/src/NzbDrone.Mono.Test/Sonarr.Mono.Test.csproj
+@@ -7,7 +7,6 @@
+        See https://github.com/xamarin/XamarinComponents/issues/282
+   -->
+   <ItemGroup>
+-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+     <PackageReference Include="Mono.Posix.NETStandard" Version="5.20.1.34-servarr24" />
+   </ItemGroup>
+   <ItemGroup>
+diff --git a/src/NzbDrone.Test.Common/NzbDroneRunner.cs b/src/NzbDrone.Test.Common/NzbDroneRunner.cs
+index 25f977fce10a74ec466ee0f8a098d77772af6ee7..11f20a88ffd8d6ac68a8f7b2e187e8cca492f5d0 100644
+--- a/src/NzbDrone.Test.Common/NzbDroneRunner.cs
++++ b/src/NzbDrone.Test.Common/NzbDroneRunner.cs
+@@ -177,6 +177,7 @@ private void GenerateConfigFile(bool enableAuth)
+                 new XElement(ConfigFileProvider.CONFIG_ELEMENT_NAME,
+                              new XElement(nameof(ConfigFileProvider.ApiKey), apiKey),
+                              new XElement(nameof(ConfigFileProvider.LogLevel), "trace"),
++                             new XElement(nameof(ConfigFileProvider.ConsoleLogLevel), "off"),
+                              new XElement(nameof(ConfigFileProvider.AnalyticsEnabled), false),
+                              new XElement(nameof(ConfigFileProvider.AuthenticationMethod), enableAuth ? "Forms" : "None"),
+                              new XElement(nameof(ConfigFileProvider.AuthenticationRequired), "DisabledForLocalAddresses"),
+diff --git a/src/NzbDrone.Update.Test/Sonarr.Update.Test.csproj b/src/NzbDrone.Update.Test/Sonarr.Update.Test.csproj
+index 5b4d7dfd789fd0a1f8e3a9af9022429537e93f56..6210493aaaeeeeec357f539102eabcad1721c627 100644
+--- a/src/NzbDrone.Update.Test/Sonarr.Update.Test.csproj
++++ b/src/NzbDrone.Update.Test/Sonarr.Update.Test.csproj
+@@ -3,7 +3,6 @@
+     <TargetFrameworks>net6.0</TargetFrameworks>
+   </PropertyGroup>
+   <ItemGroup>
+-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+   </ItemGroup>
+   <ItemGroup>
+     <ProjectReference Include="..\NzbDrone.Test.Common\Sonarr.Test.Common.csproj" />
+diff --git a/src/NzbDrone.Windows.Test/Sonarr.Windows.Test.csproj b/src/NzbDrone.Windows.Test/Sonarr.Windows.Test.csproj
+index 15bcf5d5123e4898926e628829ed186b4f1015f6..f674f3712c1e613e1b2a3c5f3ecd6c62a771018d 100644
+--- a/src/NzbDrone.Windows.Test/Sonarr.Windows.Test.csproj
++++ b/src/NzbDrone.Windows.Test/Sonarr.Windows.Test.csproj
+@@ -3,7 +3,6 @@
+     <TargetFrameworks>net6.0</TargetFrameworks>
+   </PropertyGroup>
+   <ItemGroup>
+-    <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
+   </ItemGroup>
+   <ItemGroup>
+     <ProjectReference Include="..\NzbDrone.Common.Test\Sonarr.Common.Test.csproj" />

--- a/.fork/patches/README.md
+++ b/.fork/patches/README.md
@@ -1,0 +1,10 @@
+This directory stores the maintained patch stack for the fork.
+
+The patches are generated against the upstream Sonarr release recorded in
+`.fork/upstream.json` and are replayed by the upstream sync workflow.
+
+To refresh the patch stack after intentional fork changes:
+
+```bash
+./scripts/fork/bootstrap-patches.sh
+```

--- a/.fork/upstream.json
+++ b/.fork/upstream.json
@@ -1,0 +1,9 @@
+{
+  "upstream_repository": "https://github.com/Sonarr/Sonarr.git",
+  "upstream_ref_type": "tag",
+  "upstream_ref": "v4.0.17.2952",
+  "upstream_commit": "97e85a908d4fd37c0652dd38f462cd6ddd1fa2f6",
+  "upstream_version": "4.0.17.2952",
+  "fork_ref": "8e94309dc8a4b788b08a8e3fc697c12a864ea432",
+  "patch_directory": ".fork/patches"
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,6 @@ env:
   FRAMEWORK: net6.0
   RAW_BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   SONARR_MAJOR_VERSION: 4
-  UPSTREAM_VERSION: 4.0.17.2952
 
 jobs:
   backend:
@@ -48,11 +47,15 @@ jobs:
         with:
           dotnet-version: 6.0.100
 
+      - name: Load Upstream Metadata
+        shell: bash
+        run: ./scripts/fork/export-upstream-env.sh >> "$GITHUB_ENV"
+
       - name: Setup Environment Variables
         id: variables
         shell: bash
         run: |
-          APP_VERSION="${{ env.UPSTREAM_VERSION }}"
+          APP_VERSION="${UPSTREAM_VERSION}"
           DOTNET_VERSION=$(jq -r '.sdk.version' global.json)
 
           echo "SDK_PATH=${{ env.DOTNET_ROOT }}/sdk/${DOTNET_VERSION}" >> "$GITHUB_ENV"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,7 +156,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN != '' && secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Compute Image Name
         id: image
@@ -225,7 +225,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN != '' && secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Compute Image Name
         id: image
@@ -253,7 +253,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN != '' && secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Compute Image Name
         id: image

--- a/.github/workflows/repair-latest.yml
+++ b/.github/workflows/repair-latest.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GHCR_TOKEN != '' && secrets.GHCR_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Compute Image Name
         id: image

--- a/.github/workflows/upstream-sync-ci-watch.yml
+++ b/.github/workflows/upstream-sync-ci-watch.yml
@@ -1,0 +1,68 @@
+name: Upstream Sync CI Watch
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+  pull-requests: read
+  issues: write
+
+jobs:
+  report_sync_pr_failure:
+    if: >
+      github.event.workflow_run.conclusion == 'failure' &&
+      startsWith(github.event.workflow_run.head_branch, 'automation/upstream-sync/')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Require Sync Bot Token
+        env:
+          SYNC_BOT_TOKEN: ${{ secrets.SYNC_BOT_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${SYNC_BOT_TOKEN}" ]]; then
+            echo "Missing required repository secret: SYNC_BOT_TOKEN" >&2
+            exit 1
+          fi
+
+      - name: Open Or Update Blocking Issue
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_BOT_TOKEN }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          pr_url="$(jq -r '.workflow_run.pull_requests[0].html_url // ""' "$GITHUB_EVENT_PATH")"
+
+          issue_title="Upstream sync blocked"
+          issue_body="$(cat <<EOF
+          The upstream sync PR branch is open, but CI is failing.
+
+          - Sync branch: \`${HEAD_BRANCH}\`
+          - Pull request: ${pr_url:-not available}
+          - Failed workflow run: ${RUN_URL}
+
+          Next step: inspect the failing checks on the sync PR, fix the fork delta if needed, then refresh \`.fork/patches\`.
+          EOF
+          )"
+
+          issue_number="$(gh issue list \
+            --state open \
+            --search "in:title \"${issue_title}\"" \
+            --json number \
+            --jq '.[0].number // empty')"
+
+          if [[ -n "${issue_number}" ]]; then
+            gh issue edit "${issue_number}" --title "${issue_title}" --body "${issue_body}"
+          else
+            gh issue create \
+              --title "${issue_title}" \
+              --body "${issue_body}"
+          fi

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -1,0 +1,309 @@
+name: Upstream Sync
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+    inputs:
+      upstream_ref:
+        description: "Optional upstream Sonarr tag to sync (defaults to the latest release tag)"
+        required: false
+        type: string
+      dry_run:
+        description: "Prepare the sync branch and PR, but do not enable auto-merge"
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: upstream-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    outputs:
+      skipped: ${{ steps.target.outputs.skipped }}
+      upstream_ref: ${{ steps.target.outputs.upstream_ref }}
+      upstream_version: ${{ steps.target.outputs.upstream_version }}
+      upstream_commit: ${{ steps.target.outputs.upstream_commit }}
+      sync_branch: ${{ steps.branch.outputs.sync_branch }}
+      pr_url: ${{ steps.pr.outputs.pr_url }}
+      failed_patch: ${{ steps.failed_patch.outputs.failed_patch }}
+
+    steps:
+      - name: Require Sync Bot Token
+        env:
+          SYNC_BOT_TOKEN: ${{ secrets.SYNC_BOT_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${SYNC_BOT_TOKEN}" ]]; then
+            echo "Missing required repository secret: SYNC_BOT_TOKEN" >&2
+            exit 1
+          fi
+
+      - name: Check out
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.SYNC_BOT_TOKEN }}
+
+      - name: Configure Git
+        shell: bash
+        run: |
+          git config user.name "sonarr-anime sync bot"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Resolve Target Upstream Release
+        id: target
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_BOT_TOKEN }}
+          INPUT_UPSTREAM_REF: ${{ inputs.upstream_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -n "${INPUT_UPSTREAM_REF}" ]]; then
+            upstream_ref="${INPUT_UPSTREAM_REF}"
+          else
+            upstream_ref="$(gh api repos/Sonarr/Sonarr/releases/latest --jq .tag_name)"
+          fi
+
+          git fetch --force https://github.com/Sonarr/Sonarr.git "${upstream_ref}"
+
+          upstream_commit="$(git rev-parse FETCH_HEAD)"
+          upstream_version="${upstream_ref#v}"
+          current_ref="$(jq -r '.upstream_ref' .fork/upstream.json)"
+
+          echo "upstream_ref=${upstream_ref}" >> "$GITHUB_OUTPUT"
+          echo "upstream_version=${upstream_version}" >> "$GITHUB_OUTPUT"
+          echo "upstream_commit=${upstream_commit}" >> "$GITHUB_OUTPUT"
+
+          if [[ "${current_ref}" == "${upstream_ref}" ]]; then
+            echo "skipped=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Upstream Sync"
+              echo
+              echo "- Upstream ref: \`${upstream_ref}\`"
+              echo "- Status: already synced"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "skipped=false" >> "$GITHUB_OUTPUT"
+
+      - name: Build Sync Branch Name
+        id: branch
+        if: steps.target.outputs.skipped != 'true'
+        env:
+          UPSTREAM_VERSION: ${{ steps.target.outputs.upstream_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "sync_branch=automation/upstream-sync/${UPSTREAM_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Create Sync Branch
+        if: steps.target.outputs.skipped != 'true'
+        env:
+          SYNC_BRANCH: ${{ steps.branch.outputs.sync_branch }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git checkout -B "${SYNC_BRANCH}"
+
+      - name: Prepare Synced Fork Tree
+        if: steps.target.outputs.skipped != 'true'
+        env:
+          UPSTREAM_REF: ${{ steps.target.outputs.upstream_ref }}
+          UPSTREAM_VERSION: ${{ steps.target.outputs.upstream_version }}
+          UPSTREAM_COMMIT: ${{ steps.target.outputs.upstream_commit }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./scripts/fork/prepare-upstream-sync.sh "${UPSTREAM_REF}" "${UPSTREAM_VERSION}" "${UPSTREAM_COMMIT}"
+
+      - name: Capture Failed Patch
+        id: failed_patch
+        if: failure()
+        shell: bash
+        run: |
+          set -euo pipefail
+          failed_patch=""
+          if [[ -f .fork/last_failed_patch ]]; then
+            failed_patch="$(cat .fork/last_failed_patch)"
+          fi
+          echo "failed_patch=${failed_patch}" >> "$GITHUB_OUTPUT"
+
+      - name: Commit Sync Changes
+        id: commit
+        if: steps.target.outputs.skipped != 'true'
+        env:
+          UPSTREAM_REF: ${{ steps.target.outputs.upstream_ref }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git add -A
+
+          if git diff --cached --quiet; then
+            echo "created=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Upstream Sync"
+              echo
+              echo "- Upstream ref: \`${UPSTREAM_REF}\`"
+              echo "- Status: no effective changes after patch replay"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          git commit -m "chore: sync upstream ${UPSTREAM_REF}"
+          echo "created=true" >> "$GITHUB_OUTPUT"
+
+      - name: Push Sync Branch
+        if: steps.target.outputs.skipped != 'true' && steps.commit.outputs.created == 'true'
+        env:
+          SYNC_BRANCH: ${{ steps.branch.outputs.sync_branch }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          git push --force-with-lease origin "${SYNC_BRANCH}"
+
+      - name: Create Or Update Pull Request
+        id: pr
+        if: steps.target.outputs.skipped != 'true' && steps.commit.outputs.created == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_BOT_TOKEN }}
+          SYNC_BRANCH: ${{ steps.branch.outputs.sync_branch }}
+          UPSTREAM_REF: ${{ steps.target.outputs.upstream_ref }}
+          UPSTREAM_VERSION: ${{ steps.target.outputs.upstream_version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          existing_pr="$(gh pr list \
+            --base main \
+            --head "${SYNC_BRANCH}" \
+            --state open \
+            --json number,url \
+            --jq '.[0]')"
+
+          title="chore: sync upstream ${UPSTREAM_REF}"
+          body="$(cat <<EOF
+          ## Summary
+
+          - sync upstream Sonarr release \`${UPSTREAM_REF}\`
+          - replay the maintained sonarr-anime patch stack
+          - publish via the normal \`main\` release workflow after merge
+          EOF
+          )"
+
+          if [[ -n "${existing_pr}" && "${existing_pr}" != "null" ]]; then
+            pr_number="$(jq -r '.number' <<< "${existing_pr}")"
+            pr_url="$(jq -r '.url' <<< "${existing_pr}")"
+            gh pr edit "${pr_number}" --title "${title}" --body "${body}"
+          else
+            pr_url="$(gh pr create \
+              --base main \
+              --head "${SYNC_BRANCH}" \
+              --title "${title}" \
+              --body "${body}")"
+            pr_number="$(gh pr view "${pr_url}" --json number --jq .number)"
+          fi
+
+          echo "pr_url=${pr_url}" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+
+      - name: Enable Auto-Merge
+        if: steps.pr.outputs.pr_number != '' && inputs.dry_run != true
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_BOT_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh pr merge "${PR_NUMBER}" --auto --squash
+
+      - name: Close Blocking Issue On Sync Success
+        if: steps.pr.outputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_BOT_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          issue_number="$(gh issue list \
+            --state open \
+            --search 'in:title "Upstream sync blocked"' \
+            --json number \
+            --jq '.[0].number // empty')"
+
+          if [[ -n "${issue_number}" ]]; then
+            gh issue close "${issue_number}" \
+              --comment "Closing after a new upstream sync PR was created successfully."
+          fi
+
+      - name: Summarize Sync
+        if: steps.target.outputs.skipped != 'true' && steps.pr.outputs.pr_url != ''
+        env:
+          UPSTREAM_REF: ${{ steps.target.outputs.upstream_ref }}
+          PR_URL: ${{ steps.pr.outputs.pr_url }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Upstream Sync"
+            echo
+            echo "- Upstream ref: \`${UPSTREAM_REF}\`"
+            echo "- Pull request: ${PR_URL}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  report_sync_failure:
+    runs-on: ubuntu-latest
+    needs: sync
+    if: always() && needs.sync.result == 'failure'
+
+    steps:
+      - name: Open Or Update Blocking Issue
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_BOT_TOKEN }}
+          UPSTREAM_REF: ${{ needs.sync.outputs.upstream_ref }}
+          UPSTREAM_VERSION: ${{ needs.sync.outputs.upstream_version }}
+          UPSTREAM_COMMIT: ${{ needs.sync.outputs.upstream_commit }}
+          FAILED_PATCH: ${{ needs.sync.outputs.failed_patch }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          issue_title="Upstream sync blocked"
+          issue_body="$(cat <<EOF
+          The daily upstream sync needs manual help.
+
+          - Upstream ref: \`${UPSTREAM_REF:-unknown}\`
+          - Upstream version: \`${UPSTREAM_VERSION:-unknown}\`
+          - Upstream commit: \`${UPSTREAM_COMMIT:-unknown}\`
+          - Failed patch: \`${FAILED_PATCH:-unknown}\`
+          - Workflow run: ${RUN_URL}
+
+          Next step: inspect the failing patch, update the fork changes as needed, then regenerate \`.fork/patches\` with \`./scripts/fork/bootstrap-patches.sh\`.
+          EOF
+          )"
+
+          issue_number="$(gh issue list \
+            --state open \
+            --search "in:title \"${issue_title}\"" \
+            --json number \
+            --jq '.[0].number // empty')"
+
+          if [[ -n "${issue_number}" ]]; then
+            gh issue edit "${issue_number}" --title "${issue_title}" --body "${issue_body}"
+          else
+            gh issue create \
+              --title "${issue_title}" \
+              --body "${issue_body}"
+          fi

--- a/scripts/fork/bootstrap-patches.sh
+++ b/scripts/fork/bootstrap-patches.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+METADATA_FILE="${ROOT_DIR}/.fork/upstream.json"
+PATCH_DIR="${ROOT_DIR}/.fork/patches"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+if [[ ! -f "${METADATA_FILE}" ]]; then
+  echo "Missing ${METADATA_FILE}" >&2
+  exit 1
+fi
+
+UPSTREAM_REF="${1:-$(jq -r '.upstream_ref' "${METADATA_FILE}")}"
+FORK_REF="${2:-HEAD}"
+
+cd "${ROOT_DIR}"
+
+git rev-parse --verify "${UPSTREAM_REF}^{commit}" >/dev/null
+git rev-parse --verify "${FORK_REF}^{commit}" >/dev/null
+
+rm -f "${PATCH_DIR}/"*.patch
+
+git diff --binary --full-index "${UPSTREAM_REF}" "${FORK_REF}" -- \
+  .dockerignore \
+  .github \
+  .gitignore \
+  CONTRIBUTING.md \
+  Dockerfile \
+  Dockerfile.release \
+  README.md \
+  SECURITY.md \
+  build.sh \
+  docker/tests/mono/sonarr/Dockerfile \
+  distribution/windows/setup/build.bat \
+  distribution/windows/setup/sonarr.iss \
+  frontend/src/App/AppUpdatedModalContent.tsx \
+  frontend/src/Components/Markdown/InlineMarkdown.tsx \
+  frontend/src/System/Status/About/About.tsx \
+  frontend/src/typings/SystemStatus.ts \
+  global.json \
+  local-test/docker-compose.yml \
+  src/Directory.Build.props \
+  src/Sonarr.Api.V3/System/SystemController.cs \
+  src/Sonarr.Api.V3/System/SystemResource.cs \
+  src/Sonarr.Api.V3/openapi.json \
+  > "${PATCH_DIR}/0001-release-and-branding.patch"
+
+git diff --binary --full-index "${UPSTREAM_REF}" "${FORK_REF}" -- \
+  src/NzbDrone.Core \
+  src/NzbDrone.Host/Startup.cs \
+  > "${PATCH_DIR}/0002-anime-core.patch"
+
+git diff --binary --full-index "${UPSTREAM_REF}" "${FORK_REF}" -- \
+  src/NzbDrone.Api.Test \
+  src/NzbDrone.Automation.Test \
+  src/NzbDrone.Common.Test \
+  src/NzbDrone.Core.Test \
+  src/NzbDrone.Host.Test \
+  src/NzbDrone.Integration.Test \
+  src/NzbDrone.Libraries.Test \
+  src/NzbDrone.Mono.Test \
+  src/NzbDrone.Test.Common \
+  src/NzbDrone.Update.Test \
+  src/NzbDrone.Windows.Test \
+  > "${PATCH_DIR}/0003-fork-tests.patch"
+
+jq \
+  --arg upstream_ref "${UPSTREAM_REF}" \
+  --arg upstream_commit "$(git rev-parse "${UPSTREAM_REF}^{commit}")" \
+  --arg fork_ref "$(git rev-parse "${FORK_REF}^{commit}")" \
+  --arg upstream_version "${UPSTREAM_REF#v}" \
+  '.upstream_ref = $upstream_ref
+   | .upstream_commit = $upstream_commit
+   | .upstream_version = $upstream_version
+   | .fork_ref = $fork_ref' \
+  "${METADATA_FILE}" > "${METADATA_FILE}.tmp"
+
+mv "${METADATA_FILE}.tmp" "${METADATA_FILE}"
+
+echo "Generated patch stack in ${PATCH_DIR}"

--- a/scripts/fork/export-upstream-env.sh
+++ b/scripts/fork/export-upstream-env.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+METADATA_FILE="${ROOT_DIR}/.fork/upstream.json"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+upstream_version="$(jq -r '.upstream_version' "${METADATA_FILE}")"
+upstream_ref="$(jq -r '.upstream_ref' "${METADATA_FILE}")"
+upstream_commit="$(jq -r '.upstream_commit' "${METADATA_FILE}")"
+
+echo "UPSTREAM_VERSION=${upstream_version}"
+echo "UPSTREAM_REF=${upstream_ref}"
+echo "UPSTREAM_COMMIT=${upstream_commit}"

--- a/scripts/fork/prepare-upstream-sync.sh
+++ b/scripts/fork/prepare-upstream-sync.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+METADATA_FILE="${ROOT_DIR}/.fork/upstream.json"
+FAILED_PATCH_FILE="${ROOT_DIR}/.fork/last_failed_patch"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+if [[ ! -f "${METADATA_FILE}" ]]; then
+  echo "Missing ${METADATA_FILE}" >&2
+  exit 1
+fi
+
+UPSTREAM_REF="${1:?Usage: prepare-upstream-sync.sh <upstream-ref> [upstream-version] [upstream-commit]}"
+UPSTREAM_VERSION="${2:-${UPSTREAM_REF#v}}"
+UPSTREAM_COMMIT="${3:-$(git rev-parse "${UPSTREAM_REF}^{commit}")}"
+ARCHIVE_REF="${UPSTREAM_COMMIT}"
+PATCH_DIR="$(jq -r '.patch_directory' "${METADATA_FILE}")"
+
+cd "${ROOT_DIR}"
+
+git rev-parse --verify "${ARCHIVE_REF}^{commit}" >/dev/null
+
+tmpdir="$(mktemp -d)"
+cleanup() {
+  rm -rf "${tmpdir}"
+}
+trap cleanup EXIT
+
+rm -f "${FAILED_PATCH_FILE}"
+
+git archive --format=tar "${ARCHIVE_REF}" | tar -xf - -C "${tmpdir}"
+
+find "${ROOT_DIR}" -mindepth 1 -maxdepth 1 \
+  ! -name .git \
+  ! -name .fork \
+  ! -name scripts \
+  -exec rm -rf {} +
+
+rsync -a --delete \
+  --exclude '.git' \
+  --exclude '.fork' \
+  --exclude 'scripts/fork' \
+  "${tmpdir}/" "${ROOT_DIR}/"
+
+git add -A
+
+shopt -s nullglob
+patches=("${PATCH_DIR}"/*.patch)
+shopt -u nullglob
+
+if [[ "${#patches[@]}" -eq 0 ]]; then
+  echo "No patches found in ${PATCH_DIR}" >&2
+  exit 1
+fi
+
+for patch in "${patches[@]}"; do
+  echo "Applying ${patch}"
+  printf '%s\n' "$(basename "${patch}")" > "${FAILED_PATCH_FILE}"
+  git apply --3way --whitespace=nowarn "${patch}"
+done
+
+rm -f "${FAILED_PATCH_FILE}"
+
+jq \
+  --arg upstream_ref "${UPSTREAM_REF}" \
+  --arg upstream_commit "${UPSTREAM_COMMIT}" \
+  --arg upstream_version "${UPSTREAM_VERSION}" \
+  '.upstream_ref = $upstream_ref
+   | .upstream_commit = $upstream_commit
+   | .upstream_version = $upstream_version' \
+  "${METADATA_FILE}" > "${METADATA_FILE}.tmp"
+
+mv "${METADATA_FILE}.tmp" "${METADATA_FILE}"
+
+echo "Prepared fork tree from ${UPSTREAM_REF}"


### PR DESCRIPTION
## Summary

- add a scheduled upstream sync workflow that tracks the latest Sonarr release tag
- maintain the fork as a replayable patch stack under `.fork/patches`
- derive the build/release upstream version from fork metadata instead of a hard-coded workflow constant
- open or update a blocking issue when patch replay or sync PR CI fails

## Why

This makes upstream updates largely hands-off: when Sonarr publishes a new release, the fork can reconstruct from that upstream snapshot, replay the anime-specific delta, and queue a PR for merge without requiring manual rebases.

## Validation

- parsed all workflow YAML files successfully
- validated shell syntax for the new fork scripts
- regenerated the maintained patch stack locally
- replayed the patch stack successfully against the current Sonarr base tag and the newer `v4.0.17.2953` upstream tag in a scratch copy

## Follow-up

After this PR is merged, add the `SYNC_BOT_TOKEN` repository secret and run `Upstream Sync` once with `dry_run=true` to verify the live GitHub path end to end.